### PR TITLE
GH-11 - spotify oauth2 login

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Capstone project for [neue fische's Java Development Bootcamp](https://www.neuef
 Set the following env vars for the backend application:
 ```
 OAUTH2_SUCCESS_REDIRECT_URI=http://localhost:3000
+OAUTH2_FAILURE_REDIRECT_URI=http://localhost:3000/login
 SPOTIFY_CLIENT_ID=<spotify client id>
 SPOTIFY_CLIENT_SECRET=<spotify client secret>
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Mixify
 
 Capstone project for [neue fische's Java Development Bootcamp](https://www.neuefische.de/bootcamp/java-development).
+
+## Development
+
+Set the following env vars for the backend application:
+```
+OAUTH2_SUCCESS_REDIRECT_URI=http://localhost:3000
+SPOTIFY_CLIENT_ID=<spotify client id>
+SPOTIFY_CLIENT_SECRET=<spotify client secret>
+```

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -40,6 +40,11 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -33,6 +33,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-client</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/BackendApplication.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/BackendApplication.java
@@ -1,9 +1,12 @@
 package com.github.chuettenrauch.mixifyapi;
 
+import com.github.chuettenrauch.mixifyapi.config.AppProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(AppProperties.class)
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/config/AppProperties.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/config/AppProperties.java
@@ -7,11 +7,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "app")
 @Getter
 public class AppProperties {
-    private final OAuth2 oauth2 = new OAuth2();
+    private final OAuth2 oAuth2 = new OAuth2();
 
     @Getter
     @Setter
     public static class OAuth2 {
         private String successRedirectUri;
+        private String failureRedirectUri;
     }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/config/AppProperties.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/config/AppProperties.java
@@ -1,0 +1,17 @@
+package com.github.chuettenrauch.mixifyapi.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app")
+@Getter
+public class AppProperties {
+    private final OAuth2 oauth2 = new OAuth2();
+
+    @Getter
+    @Setter
+    public static class OAuth2 {
+        private String successRedirectUri;
+    }
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/SecurityConfig.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/SecurityConfig.java
@@ -2,19 +2,34 @@ package com.github.chuettenrauch.mixifyapi.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
 
-    // temporarily disable spring security
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf().disable()
-                .authorizeHttpRequests(authorize ->
-                        authorize.anyRequest().permitAll()
+                .cors().disable()
+                .formLogin().disable()
+                .httpBasic().disable()
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/oauth2/**").permitAll()
+                        .anyRequest().permitAll()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .redirectionEndpoint(config -> config
+                                .baseUri("/oauth2/code/*")
+                        )
+                )
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
                 .build();
     }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/SecurityConfig.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/SecurityConfig.java
@@ -1,16 +1,19 @@
 package com.github.chuettenrauch.mixifyapi.security;
 
+import com.github.chuettenrauch.mixifyapi.config.AppProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.*;
 
 @Configuration
-@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final AppProperties appProperties;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -27,10 +30,17 @@ public class SecurityConfig {
                         .redirectionEndpoint(config -> config
                                 .baseUri("/oauth2/code/*")
                         )
+                        .successHandler(authenticationSuccessHandler(
+                                appProperties.getOauth2().getSuccessRedirectUri()
+                        ))
                 )
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
                 .build();
+    }
+
+    private AuthenticationSuccessHandler authenticationSuccessHandler(String redirectUri) {
+        return new SimpleUrlAuthenticationSuccessHandler(redirectUri);
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.data.mongodb.uri=${MONGO_URI:mongodb://localhost:27017}
-spring.data.mongodb.database=${MONGO_DATABASE:mixify}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -26,3 +26,4 @@ spring:
 app:
   oauth2:
     success-redirect-uri: "${OAUTH2_SUCCESS_REDIRECT_URI:/}"
+    failure-redirect-uri: "${OAUTH2_FAILURE_REDIRECT_URI:/login}"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,3 +22,7 @@ spring:
             token-uri: https://accounts.spotify.com/api/token
             user-info-uri: https://api.spotify.com/v1/me
             user-name-attribute: display_name
+
+app:
+  oauth2:
+    success-redirect-uri: "${OAUTH2_SUCCESS_REDIRECT_URI:/}"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  data:
+    mongodb:
+      uri: "${MONGO_URI:mongodb://localhost:27017}"
+      database: "${MONGO_DATABASE:mixify}"
+
+  security:
+    oauth2:
+      client:
+        registration:
+          spotify:
+            client-id: "${SPOTIFY_CLIENT_ID}"
+            client-secret: "${SPOTIFY_CLIENT_SECRET}"
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/oauth2/code/{registrationId}"
+            scope:
+              - user-read-private
+              - user-read-email
+        provider:
+          spotify:
+            authorization-uri: https://accounts.spotify.com/authorize
+            token-uri: https://accounts.spotify.com/api/token
+            user-info-uri: https://api.spotify.com/v1/me
+            user-name-attribute: display_name

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/config/AppPropertiesTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/config/AppPropertiesTest.java
@@ -1,0 +1,33 @@
+package com.github.chuettenrauch.mixifyapi.integration.config;
+
+import com.github.chuettenrauch.mixifyapi.config.AppProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(
+        classes = { AppPropertiesTest.TestApplication.class },
+        properties = {
+            "app.o-auth2.success-redirect-uri=/success",
+            "app.o-auth2.failure-redirect-uri=/failure",
+        }
+)
+public class AppPropertiesTest {
+
+    @Autowired
+    private AppProperties appProperties;
+
+    @Test
+    void correctlyBindsPropertiesToAppConfig() {
+        AppProperties.OAuth2 oauth2 = appProperties.getOAuth2();
+
+        assertEquals("/success", oauth2.getSuccessRedirectUri());
+        assertEquals("/failure", oauth2.getFailureRedirectUri());
+    }
+
+    @EnableConfigurationProperties(AppProperties.class)
+    public static class TestApplication {}
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/config/AppPropertiesTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/config/AppPropertiesTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
             "app.o-auth2.failure-redirect-uri=/failure",
         }
 )
-public class AppPropertiesTest {
+class AppPropertiesTest {
 
     @Autowired
     private AppProperties appProperties;

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://localhost:8080

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,7 @@
 import {Button, Container, Typography} from "@mui/material";
 
+const authorizeUrl = `${process.env.REACT_APP_API_BASE_URL ?? ""}/oauth2/authorization/spotify`;
+
 export default function LoginPage() {
     return (
         <Container maxWidth="md" sx={{
@@ -16,7 +18,7 @@ export default function LoginPage() {
                 <Typography>
                     Bring back the nostalgia of creating and sharing mixtapes like in the good old days of cassette tapes
                 </Typography>
-                <Button variant="contained" href="/oauth/authorize/spotify">
+                <Button variant="contained" href={authorizeUrl}>
                     Continue with spotify
                 </Button>
         </Container>


### PR DESCRIPTION
Ich hab leider keine Ahnung, wie ich das sinnvoll Testen kann. Hab ein bißchen rumgeguckt, ob es für den eingebauten OAuth2 von Spring Security irgendwelche Testsachen gibt, aber hab nichts gefunden, womit ich was anfangen kann. 

Manuell kann man das auf jeden Fall testen - dazu braucht man aber nen Spotify Account und ich muss den im Spotify Dev Dashboard freigeben für die App. Da einfach Bescheid sagen. 
Wenn man dann auf `http://localhost:3000/login` geht und auf den Button klickt, sollte man zu Spotify Login kommen - wenn man da accepted, dann sollte man auf /mixtapes kommen und eine `JSESSIONID` haben.

Ansonsten meckert Sonar gerade, weil meine Testabdeckung zu niedrig ist - ich würde das an der Stelle mal ignorieren. 
Die SecurityFilterChain wird dann auf jeden Fall in zukünfigten PRs zB beim `/me`- Endpunkt mitgetestet werden.