### PR TITLE
GH-16 - /me endpoint

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: frontend
         run: npm install && npm run build
       - name: "Copy assets"
-        run: cp -r frontend/build backend/src/main/resources/static
+        run: cp -r frontend/build/ backend/src/main/resources/static
       - name: "Build backend"
         working-directory: backend
         run: mvn -B package -D maven.test.skip --file pom.xml

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -52,7 +52,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -90,6 +90,11 @@
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.8</version>
+				<configuration>
+					<excludes>
+						<exclude>com/example/backend/BackendApplication.class</exclude>
+					</excludes>
+				</configuration>
 				<executions>
 					<execution>
 						<goals>

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/exception/NoSuchOAuth2MapperException.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/exception/NoSuchOAuth2MapperException.java
@@ -1,0 +1,4 @@
+package com.github.chuettenrauch.mixifyapi.security.exception;
+
+public class NoSuchOAuth2MapperException extends RuntimeException {
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/mapper/OAuth2UserMapperFactory.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/mapper/OAuth2UserMapperFactory.java
@@ -1,0 +1,30 @@
+package com.github.chuettenrauch.mixifyapi.security.mapper;
+
+import com.github.chuettenrauch.mixifyapi.security.exception.NoSuchOAuth2MapperException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class OAuth2UserMapperFactory {
+    private final Map<String, OAuth2UserMapper> oAuth2UserMapperByProvider;
+
+    public OAuth2UserMapperFactory(List<OAuth2UserMapper> oAuth2UserMappers) {
+        this.oAuth2UserMapperByProvider = oAuth2UserMappers
+                .stream()
+                .collect(
+                        Collectors.toMap(oAuth2UserMapper -> oAuth2UserMapper.getProvider().toString(), Function.identity())
+                );
+    }
+
+    public OAuth2UserMapper getOAuth2UserMapperByProviderName(String providerName) {
+        if (!this.oAuth2UserMapperByProvider.containsKey(providerName)) {
+            throw new NoSuchOAuth2MapperException();
+        }
+
+        return this.oAuth2UserMapperByProvider.get(providerName);
+    }
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/controller/UserController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/controller/UserController.java
@@ -1,0 +1,25 @@
+package com.github.chuettenrauch.mixifyapi.user.controller;
+
+import com.github.chuettenrauch.mixifyapi.user.model.UserResource;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public UserResource me(Authentication authentication, @RegisteredOAuth2AuthorizedClient OAuth2AuthorizedClient authorizedClient) {
+        return this.userService.createUserResource((OAuth2AuthenticationToken) authentication, authorizedClient);
+    }
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/model/User.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/model/User.java
@@ -19,6 +19,7 @@ public class User {
     private String email;
     private String name;
     private String imageUrl;
+
     private Provider provider;
     private String providerId;
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/model/UserResource.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/model/UserResource.java
@@ -1,0 +1,14 @@
+package com.github.chuettenrauch.mixifyapi.user.model;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@RequiredArgsConstructor
+public class UserResource {
+    @NonNull private String name;
+    @NonNull private String imageUrl;
+    @NonNull private String providerAccessToken;
+    private String providerRefreshToken;
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/service/UserService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/service/UserService.java
@@ -1,8 +1,15 @@
 package com.github.chuettenrauch.mixifyapi.user.service;
 
+import com.github.chuettenrauch.mixifyapi.security.mapper.OAuth2UserMapper;
+import com.github.chuettenrauch.mixifyapi.security.mapper.OAuth2UserMapperFactory;
 import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.model.UserResource;
 import com.github.chuettenrauch.mixifyapi.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -13,11 +20,33 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    private final OAuth2UserMapperFactory oAuth2UserMapperFactory;
+
     public Optional<User> findByEmail(String email) {
         return this.userRepository.findByEmail(email);
     }
 
     public User save(User user) {
         return this.userRepository.save(user);
+    }
+
+    public UserResource createUserResource(OAuth2AuthenticationToken authentication, OAuth2AuthorizedClient authorizedClient) {
+        OAuth2User oAuth2User = authentication.getPrincipal();
+
+        OAuth2UserMapper oAuth2UserMapper = this.oAuth2UserMapperFactory.getOAuth2UserMapperByProviderName(authentication.getAuthorizedClientRegistrationId());
+        User user = oAuth2UserMapper.mapOAuth2UserToUser(oAuth2User, new User());
+
+        UserResource userResource = new UserResource(
+                user.getName(),
+                user.getImageUrl(),
+                authorizedClient.getAccessToken().getTokenValue()
+        );
+
+        OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
+        if (refreshToken != null) {
+            userResource.setProviderRefreshToken(refreshToken.getTokenValue());
+        }
+
+        return userResource;
     }
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/security/listener/OAuth2AuthenticationSuccessEventListenerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/security/listener/OAuth2AuthenticationSuccessEventListenerTest.java
@@ -7,11 +7,9 @@ import com.github.chuettenrauch.mixifyapi.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationToken;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -36,10 +34,8 @@ class OAuth2AuthenticationSuccessEventListenerTest {
     @Autowired
     private UserRepository userRepository;
 
-    @MockBean
-    private ClientRegistrationRepository clientRegistrationRepository;
-
     @Test
+    @DirtiesContext
     void saveUserOnAuthenticationSuccess_createsNewUserIfUserDoesNotExistAlready() {
         // given
         String expectedImageUrl = "http://url/to/image-1.jpg";

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/user/controller/UserControllerTest.java
@@ -1,0 +1,91 @@
+package com.github.chuettenrauch.mixifyapi.integration.user.controller;
+
+import com.github.chuettenrauch.mixifyapi.user.model.Provider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Client;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void me_returnsUnauthorizedIfNotLoggedIn() throws Exception {
+        this.mvc.perform(get("/api/users/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DirtiesContext
+    void me_returnsUserResourceIfLoggedIn() throws Exception {
+        // given
+        String expectedJson = """
+                {
+                    "name": "alvin",
+                    "imageUrl": "http://path/to/image.jpg",
+                    "providerAccessToken": "access-token",
+                    "providerRefreshToken": null
+                }
+                """;
+
+        // when + then
+        this.mvc.perform(get("/api/users/me")
+                        .with(this.createOAuth2Login("alvin", "http://path/to/image.jpg"))
+                        .with(this.createOAuth2Client("access-token"))
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson, true));
+    }
+
+    private ClientRegistration createOAuth2ClientRegistration() {
+        return ClientRegistration
+                .withRegistrationId(Provider.spotify.toString())
+                .clientId("doesntmatter")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .authorizationUri("doesntmatter")
+                .redirectUri("doesntmatter")
+                .tokenUri("doesntmatter")
+                .build();
+    }
+
+    private SecurityMockMvcRequestPostProcessors.OAuth2ClientRequestPostProcessor createOAuth2Client(String accessToken) {
+        return oauth2Client()
+                .clientRegistration(this.createOAuth2ClientRegistration())
+                .accessToken(new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, accessToken, null, null));
+    }
+
+    private SecurityMockMvcRequestPostProcessors.OAuth2LoginRequestPostProcessor createOAuth2Login(String name, String imageUrl) {
+        return oauth2Login()
+                .clientRegistration(this.createOAuth2ClientRegistration())
+                .attributes(attrs -> {
+                    attrs.put("display_name", name);
+                    attrs.put("email", "alvi@chipmunks.de");
+                    attrs.put("images", new ArrayList<>(List.of(
+                            Map.of(
+                                    "url", imageUrl
+                            )
+                    )));
+                    attrs.put("id", "user-123");
+                });
+    }
+
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/security/mapper/OAuth2UserMapperFactoryTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/security/mapper/OAuth2UserMapperFactoryTest.java
@@ -1,0 +1,43 @@
+package com.github.chuettenrauch.mixifyapi.unit.security.mapper;
+
+import com.github.chuettenrauch.mixifyapi.security.exception.NoSuchOAuth2MapperException;
+import com.github.chuettenrauch.mixifyapi.security.mapper.OAuth2UserMapper;
+import com.github.chuettenrauch.mixifyapi.security.mapper.OAuth2UserMapperFactory;
+import com.github.chuettenrauch.mixifyapi.user.model.Provider;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+
+class OAuth2UserMapperFactoryTest {
+
+    @Test
+    void getOAuth2UserMapperByProviderName_returnsMapperWithGivenProviderName() {
+        // given
+        Provider provider = Provider.spotify;
+
+        OAuth2UserMapper expectedMapper = mock(OAuth2UserMapper.class);
+        when(expectedMapper.getProvider()).thenReturn(provider);
+
+        // when
+        OAuth2UserMapperFactory sut = new OAuth2UserMapperFactory(List.of(
+                expectedMapper
+        ));
+
+        OAuth2UserMapper actual = sut.getOAuth2UserMapperByProviderName(provider.toString());
+
+        // then
+        assertEquals(expectedMapper, actual);
+    }
+
+    @Test
+    void getOAuth2UserMapperByProviderName_throwsNoSuchOAuth2MapperExceptionIfMapperForProviderNameDoesNotExist() {
+        OAuth2UserMapperFactory sut = new OAuth2UserMapperFactory(List.of());
+
+        assertThrows(NoSuchOAuth2MapperException.class, () -> sut.getOAuth2UserMapperByProviderName("does-not-exist"));
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/user/service/UserServiceTest.java
@@ -1,9 +1,18 @@
 package com.github.chuettenrauch.mixifyapi.unit.user.service;
 
+import com.github.chuettenrauch.mixifyapi.security.mapper.OAuth2UserMapper;
+import com.github.chuettenrauch.mixifyapi.security.mapper.OAuth2UserMapperFactory;
+import com.github.chuettenrauch.mixifyapi.user.model.Provider;
 import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.model.UserResource;
 import com.github.chuettenrauch.mixifyapi.user.repository.UserRepository;
 import com.github.chuettenrauch.mixifyapi.user.service.UserService;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Optional;
 
@@ -21,8 +30,10 @@ class UserServiceTest {
         UserRepository userRepository = mock(UserRepository.class);
         when(userRepository.findByEmail(email)).thenReturn(expected);
 
+        OAuth2UserMapperFactory oAuth2UserMapperFactory = mock(OAuth2UserMapperFactory.class);
+
         // when
-        UserService sut = new UserService(userRepository);
+        UserService sut = new UserService(userRepository, oAuth2UserMapperFactory);
         Optional<User> actual = sut.findByEmail(email);
 
         // then
@@ -38,13 +49,89 @@ class UserServiceTest {
         UserRepository userRepository = mock(UserRepository.class);
         when(userRepository.save(expected)).thenReturn(expected);
 
+        OAuth2UserMapperFactory oAuth2UserMapperFactory = mock(OAuth2UserMapperFactory.class);
+
         // when
-        UserService sut = new UserService(userRepository);
+        UserService sut = new UserService(userRepository, oAuth2UserMapperFactory);
         User actual = sut.save(expected);
 
         // then
         assertEquals(expected, actual);
         verify(userRepository).save(expected);
+    }
+
+    @Test
+    void createUserResourceFromAuthentication_returnsUserResource() {
+        // given
+        User user = new User("123", "alvin", "alvin@chipmunks.de", "/path/to/image", Provider.spotify, "user-123");
+        String accessToken = "access-token";
+        String refreshToken = "refresh-token";
+
+        OAuth2User oAuth2User = mock(OAuth2User.class);
+
+        OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        when(authentication.getPrincipal()).thenReturn(oAuth2User);
+
+        OAuth2AuthorizedClient authorizedClient = this.mockOAuth2AuthorizedClient(accessToken, refreshToken);
+        OAuth2UserMapperFactory oAuth2UserMapperFactory = this.mockOAuth2UserMapperFactory(user);
+
+        UserRepository userRepository = mock(UserRepository.class);
+
+        // when
+        UserService sut = new UserService(userRepository, oAuth2UserMapperFactory);
+        UserResource actual = sut.createUserResource(authentication, authorizedClient);
+
+        // then
+        assertEquals(user.getName(), actual.getName());
+        assertEquals(user.getImageUrl(), actual.getImageUrl());
+        assertEquals(accessToken, actual.getProviderAccessToken());
+        assertEquals(refreshToken, actual.getProviderRefreshToken());
+    }
+
+    @Test
+    void createUserResourceFromAuthentication_skipsRefreshTokenIfNotPresent() {
+        // given
+        User user = new User("123", "alvin", "alvin@chipmunks.de", "/path/to/image", Provider.spotify, "user-123");
+        OAuth2User oAuth2User = mock(OAuth2User.class);
+
+        OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        when(authentication.getPrincipal()).thenReturn(oAuth2User);
+
+        OAuth2AuthorizedClient authorizedClient = this.mockOAuth2AuthorizedClient("does-not-matter", null);
+        OAuth2UserMapperFactory oAuth2UserMapperFactory = this.mockOAuth2UserMapperFactory(user);
+
+        UserRepository userRepository = mock(UserRepository.class);
+
+        // when
+        UserService sut = new UserService(userRepository, oAuth2UserMapperFactory);
+        UserResource actual = sut.createUserResource(authentication, authorizedClient);
+
+        // then
+        assertNull(actual.getProviderRefreshToken());
+    }
+
+    private OAuth2AuthorizedClient mockOAuth2AuthorizedClient(String accessToken, String refreshToken) {
+        OAuth2AccessToken oAuth2AccessToken = mock(OAuth2AccessToken.class);
+        when(oAuth2AccessToken.getTokenValue()).thenReturn(accessToken);
+
+        OAuth2RefreshToken oAuth2RefreshToken = mock(OAuth2RefreshToken.class);
+        when(oAuth2RefreshToken.getTokenValue()).thenReturn(refreshToken);
+
+        OAuth2AuthorizedClient authorizedClient = mock(OAuth2AuthorizedClient.class);
+        when(authorizedClient.getAccessToken()).thenReturn(oAuth2AccessToken);
+        when(authorizedClient.getRefreshToken()).thenReturn(oAuth2RefreshToken);
+
+        return authorizedClient;
+    }
+
+    private OAuth2UserMapperFactory mockOAuth2UserMapperFactory(User returnedUser) {
+        OAuth2UserMapper oAuth2UserMapper = mock(OAuth2UserMapper.class);
+        when(oAuth2UserMapper.mapOAuth2UserToUser(any(), any())).thenReturn(returnedUser);
+
+        OAuth2UserMapperFactory oAuth2UserMapperFactory = mock(OAuth2UserMapperFactory.class);
+        when(oAuth2UserMapperFactory.getOAuth2UserMapperByProviderName(any())).thenReturn(oAuth2UserMapper);
+
+        return oAuth2UserMapperFactory;
     }
 
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -4,6 +4,26 @@ de:
       embedded:
         version: 5.0.14
 
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          spotify:
+            client-id: "client-id"
+            client-secret: "client-secret"
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/oauth2/code/{registrationId}"
+            scope:
+              - user-read-private
+              - user-read-email
+        provider:
+          spotify:
+            authorization-uri: https://accounts.spotify.com/authorize
+            token-uri: https://accounts.spotify.com/api/token
+            user-info-uri: https://api.spotify.com/v1/me
+            user-name-attribute: display_name
+
 app:
   oauth2:
     success-redirect-uri: "/"


### PR DESCRIPTION
- /me Endpunkt hinzugefügt, der nötige Userdaten fürs Frontend zurückgibt (name, imageUrl, accessToken, refreshToken)
- bugfix, dass frontend assets in den falschen ordner kopiert wurden, weswegen die App auf fly nicht lief
- BackendApplication von code-coverage ausgeschlossen
- lombok nicht mehr als optionale dependency, sondern required

**Testen**
- auf `http://localhost:3000/login` gehen und Button klicken
- mit folgenden Userdaten einloggen:
  - email: `remaka5086@ukbob.com`
  - passwd: `bo-java-22-1`
- In den Chrome DevTools unter `Application` -> links dann `Cookies` dan Wert vom `JSESSIONID` Cookie kopieren
- in Postman einen GET-Request an `http://localhost:8080/api/users/me` machen -> sollte unauthorized sein
- in den Cookies in Postman den kopierten Wert eintragen und den Request nochmal abschicken -> jetzt sollten Name, ImageUrl und 2 Token zurückkommen