### PR TITLE
GH-18 - logout endpoint

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -91,7 +91,7 @@
 				<version>0.8.8</version>
 				<configuration>
 					<excludes>
-						<exclude>com/example/backend/BackendApplication.class</exclude>
+						<exclude>com/github/chuettenrauch/mixifyapi/BackendApplication.class</exclude>
 					</excludes>
 				</configuration>
 				<executions>

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/controller/UserController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/controller/UserController.java
@@ -2,12 +2,14 @@ package com.github.chuettenrauch.mixifyapi.user.controller;
 
 import com.github.chuettenrauch.mixifyapi.user.model.UserResource;
 import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +23,10 @@ public class UserController {
     @GetMapping("/me")
     public UserResource me(Authentication authentication, @RegisteredOAuth2AuthorizedClient OAuth2AuthorizedClient authorizedClient) {
         return this.userService.createUserResource((OAuth2AuthenticationToken) authentication, authorizedClient);
+    }
+
+    @PostMapping("/logout")
+    public void logout(HttpSession httpSession) {
+        httpSession.invalidate();
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,5 +25,5 @@ spring:
 
 app:
   oauth2:
-    success-redirect-uri: "${OAUTH2_SUCCESS_REDIRECT_URI:/}"
-    failure-redirect-uri: "${OAUTH2_FAILURE_REDIRECT_URI:/login}"
+    success-redirect-uri: "${OAUTH2_SUCCESS_REDIRECT_URI:http://localhost:3000}"
+    failure-redirect-uri: "${OAUTH2_FAILURE_REDIRECT_URI:http://localhost:3000/login}"

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/user/controller/UserControllerTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
@@ -16,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Client;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -54,6 +57,25 @@ class UserControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson, true));
+    }
+
+    @Test
+    void logout_returnsUnauthorizedIfNotLoggedIn() throws Exception {
+        this.mvc.perform(post("/api/users/logout"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void logout_invalidatesSession() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+
+        this.mvc.perform(post("/api/users/logout")
+                        .session(session)
+                )
+                .andExpect(status().isOk());
+
+        assertTrue(session.isInvalid());
     }
 
     private ClientRegistration createOAuth2ClientRegistration() {


### PR DESCRIPTION
- Logout Endpunkt, der die Session cleared
- fix des excludes, der BackendApplication nicht in der code coverage berücksichtigen soll
- defaultwerte für sucess- und failure redirect url so umgestellt, dass man sie in Dev nicht extra konfigurieren muss