### PR TITLE
GH-20 - make user related routes only accessible, if logged in

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,23 +6,28 @@ import PlayMixtapePage from "./pages/PlayMixtapePage";
 import LoginPage from "./pages/LoginPage";
 import MixtapeDetailPage from "./pages/MixtapeDetailPage";
 import MainLayout from "./components/MainLayout";
+import ProtectedRoutes from "./components/ProtectedRoutes";
+import {UserProvider} from "./context/userContext";
 
 function App() {
     return (
-        <>
+        <UserProvider>
             <CssBaseline/>
             <BrowserRouter>
                 <Routes>
-                    <Route element={<MainLayout/>}>
-                        <Route path="/" element={<Navigate to="/mixtapes"/>}/> {/* redirect dashboard to mixtapes page for now, as the dashboard is optional */}
-                        <Route path="/mixtapes" element={<MixtapesOverviewPage/>}/>
-                        <Route path="/mixtapes/:id" element={<MixtapeDetailPage/>}/>
-                        <Route path="/play/:id" element={<PlayMixtapePage/>}/>
+                    <Route element={<ProtectedRoutes/>}>
+                        <Route element={<MainLayout/>}>
+                            <Route path="/" element={<Navigate to="/mixtapes"/>}/> {/* redirect dashboard to mixtapes page for now, as the dashboard is optional */}
+                            <Route path="/mixtapes" element={<MixtapesOverviewPage/>}/>
+                            <Route path="/mixtapes/:id" element={<MixtapeDetailPage/>}/>
+                            <Route path="/play/:id" element={<PlayMixtapePage/>}/>
+                        </Route>
                     </Route>
+
                     <Route path="/login" element={<LoginPage/>}/>
                 </Routes>
             </BrowserRouter>
-        </>
+        </UserProvider>
     );
 }
 

--- a/frontend/src/api/mixify-api.ts
+++ b/frontend/src/api/mixify-api.ts
@@ -1,0 +1,14 @@
+import User from "../types/user";
+import axios from "axios";
+
+export module UserApi {
+    const client = axios.create({
+        baseURL: "/api/users"
+    });
+
+    export async function getAuthenticatedUser(): Promise<User> {
+        const response = await client.get("/me");
+
+        return response.data;
+    }
+}

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -1,0 +1,32 @@
+import {Navigate, Outlet} from "react-router-dom";
+import {useUserContext} from "../context/userContext";
+import {useEffect, useState} from "react";
+import {UserApi} from "../api/mixify-api";
+
+export default function ProtectedRoutes() {
+    const {user, setUser} = useUserContext();
+    const [loading, setLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const authenticatedUser = await UserApi.getAuthenticatedUser();
+                setUser(authenticatedUser);
+            } catch (e) {
+                // do nothing
+            } finally {
+                setLoading(false);
+            }
+        })();
+    }, [setUser]);
+
+    if (loading) {
+        return null;
+    }
+
+    return (
+        user
+            ? <Outlet/>
+            : <Navigate to="/login"/>
+    )
+}

--- a/frontend/src/context/userContext.tsx
+++ b/frontend/src/context/userContext.tsx
@@ -1,0 +1,23 @@
+import User from "../types/user";
+import {createContext, Dispatch, ReactNode, SetStateAction, useContext, useState} from "react";
+
+const UserContext = createContext<{user: User|null, setUser: Dispatch<SetStateAction<User|null>>}>({
+    user: null,
+    setUser: () => undefined
+});
+
+export function UserProvider({children}: {
+    children: ReactNode|ReactNode[]
+}) {
+    const [user, setUser] = useState<User|null>(null);
+
+    return (
+        <UserContext.Provider value={{user, setUser}}>
+            {children}
+        </UserContext.Provider>
+    )
+}
+
+export function useUserContext() {
+    return useContext(UserContext);
+}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,8 @@
+type User = {
+    name: string,
+    imageUrl: string,
+    providerAccessToken: string,
+    providerRefreshToken: string
+}
+
+export default User;


### PR DESCRIPTION
**Testen**
- für Spring müssen erstmal zwei ENV Vars `SPOTIFY_CLIENT_ID` und `SPOTIFY_CLIENT_SECRET` festgelegt werden (da einfach kurz bei Slack anschreiben, dann geb ich durch, welche Werte gesetzt werden müssen)
- `http:/localhost:3000` aufrufen -> sollte auf `/login` weiterleitet werden
- Login Button drücken und bei Spotify einloggen (hier am besten auch kurz nochmal bei Slack bescheid sagen, dann geb ich die Testuserdaten durch)
- danach sollte man auf `http://localhost:3000/mixtapes` kommen
- gern auch nochmal ne andere Route probieren, z.B. `http://localhost:3000/mixtapes/123` 
- Dann in den DevTools unter `Application` -> `Cookies` den `JSESSIONID`-Cookie löschen und die Seite reloaden
- man sollte jetzt wieder auf `/login` landen