### PR TITLE
GH-32 - POST mixtape endpoint

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -37,6 +37,10 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-client</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -19,6 +19,9 @@
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.project.key>mixify-backend</sonar.project.key>
 		<sonar.project.name>mixify-backend</sonar.project.name>
+		<sonar.issue.ignore.multicriteria>dto</sonar.issue.ignore.multicriteria>
+		<sonar.issue.ignore.multicriteria.dto.ruleKey>java:S4684</sonar.issue.ignore.multicriteria.dto.ruleKey>
+		<sonar.issue.ignore.multicriteria.dto.resourceKey>**/*Controller.java</sonar.issue.ignore.multicriteria.dto.resourceKey>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/audit/config/AuditConfig.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/audit/config/AuditConfig.java
@@ -1,0 +1,10 @@
+package com.github.chuettenrauch.mixifyapi.audit.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class AuditConfig {
+
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/audit/provider/AuditorProvider.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/audit/provider/AuditorProvider.java
@@ -10,12 +10,12 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class AuditorProvider implements AuditorAware<String> {
+public class AuditorProvider implements AuditorAware<User> {
 
     private final UserService userService;
 
     @Override
-    public Optional<String> getCurrentAuditor() {
-        return this.userService.getAuthenticatedUser().map(User::getId);
+    public Optional<User> getCurrentAuditor() {
+        return this.userService.getAuthenticatedUser();
     }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/audit/provider/AuditorProvider.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/audit/provider/AuditorProvider.java
@@ -1,0 +1,21 @@
+package com.github.chuettenrauch.mixifyapi.audit.provider;
+
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class AuditorProvider implements AuditorAware<String> {
+
+    private final UserService userService;
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return this.userService.getAuthenticatedUser().map(User::getId);
+    }
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/file/validation/IsOwnedByAuthenticatedUser.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/file/validation/IsOwnedByAuthenticatedUser.java
@@ -1,0 +1,17 @@
+package com.github.chuettenrauch.mixifyapi.file.validation;
+
+import com.github.chuettenrauch.mixifyapi.file.validation.validator.IsOwnedByAuthenticatedUserValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = IsOwnedByAuthenticatedUserValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IsOwnedByAuthenticatedUser {
+    String message() default "File must be owner by authenticated user.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/file/validation/validator/IsOwnedByAuthenticatedUserValidator.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/file/validation/validator/IsOwnedByAuthenticatedUserValidator.java
@@ -1,0 +1,35 @@
+package com.github.chuettenrauch.mixifyapi.file.validation.validator;
+
+import com.github.chuettenrauch.mixifyapi.file.service.FileService;
+import com.github.chuettenrauch.mixifyapi.file.validation.IsOwnedByAuthenticatedUser;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class IsOwnedByAuthenticatedUserValidator implements ConstraintValidator<IsOwnedByAuthenticatedUser, String> {
+
+    private final FileService fileService;
+
+    private final UserService userService;
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        Optional<User> authenticatedUser = this.userService.getAuthenticatedUser();
+
+        if (authenticatedUser.isEmpty()) {
+            return false;
+        }
+
+        try {
+            this.fileService.findFileByIdForUser(s, authenticatedUser.get());
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
@@ -1,0 +1,21 @@
+package com.github.chuettenrauch.mixifyapi.mixtape.controller;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/mixtapes")
+@RequiredArgsConstructor
+public class MixtapeController {
+
+    private final MixtapeService mixtapeService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mixtape create(@RequestBody Mixtape mixtape) {
+        return this.mixtapeService.save(mixtape);
+    }
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
@@ -2,6 +2,7 @@ package com.github.chuettenrauch.mixifyapi.mixtape.controller;
 
 import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
 import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -15,7 +16,7 @@ public class MixtapeController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Mixtape create(@RequestBody Mixtape mixtape) {
+    public Mixtape create(@Valid @RequestBody Mixtape mixtape) {
         return this.mixtapeService.save(mixtape);
     }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
@@ -1,0 +1,35 @@
+package com.github.chuettenrauch.mixifyapi.mixtape.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.DocumentReference;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Document
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Mixtape {
+    @Id
+    private String id;
+    private String title;
+    private String description;
+    private String image;
+
+    @JsonIgnore
+    @DocumentReference(lazy = true)
+    private List<Track> tracks = new ArrayList<>();
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    private String createdBy;
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
@@ -1,6 +1,7 @@
 package com.github.chuettenrauch.mixifyapi.mixtape.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.chuettenrauch.mixifyapi.file.validation.IsOwnedByAuthenticatedUser;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,8 @@ public class Mixtape {
     private String id;
     private String title;
     private String description;
+
+    @IsOwnedByAuthenticatedUser
     private String image;
 
     @JsonIgnore

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
@@ -2,6 +2,7 @@ package com.github.chuettenrauch.mixifyapi.mixtape.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.chuettenrauch.mixifyapi.file.validation.IsOwnedByAuthenticatedUser;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -34,5 +35,6 @@ public class Mixtape {
     private LocalDateTime createdAt;
 
     @CreatedBy
-    private String createdBy;
+    @DocumentReference(lazy = true)
+    private User createdBy;
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Track.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Track.java
@@ -1,0 +1,16 @@
+package com.github.chuettenrauch.mixifyapi.mixtape.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Track {
+    @Id
+    private String id;
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/repository/MixtapeRepository.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/repository/MixtapeRepository.java
@@ -1,0 +1,9 @@
+package com.github.chuettenrauch.mixifyapi.mixtape.repository;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MixtapeRepository extends MongoRepository<Mixtape, String> {
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -1,0 +1,17 @@
+package com.github.chuettenrauch.mixifyapi.mixtape.service;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.repository.MixtapeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MixtapeService {
+
+    private final MixtapeRepository mixtapeRepository;
+
+    public Mixtape save(Mixtape mixtape) {
+        return this.mixtapeRepository.save(mixtape);
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/audit/provider/AuditorProviderTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/audit/provider/AuditorProviderTest.java
@@ -1,0 +1,47 @@
+package com.github.chuettenrauch.mixifyapi.audit.provider;
+
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuditorProviderTest {
+
+    @Test
+    void getCurrentAuditor_whenLoggedIn_thenReturnUserId() {
+        // given
+        User user = new User();
+        user.setId("123");
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        AuditorProvider sut = new AuditorProvider(userService);
+        Optional<String> actual = sut.getCurrentAuditor();
+
+        // then
+        assertTrue(actual.isPresent());
+        assertEquals(user.getId(), actual.get());
+    }
+
+    @Test
+    void getCurrentAuditor_whenNotLoggedIn_thenReturnEmpty() {
+        // given
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
+
+        // when
+        AuditorProvider sut = new AuditorProvider(userService);
+        Optional<String> actual = sut.getCurrentAuditor();
+
+        // then
+        assertTrue(actual.isEmpty());
+    }
+
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -85,4 +85,36 @@ class MixtapeControllerTest {
                 .andExpect(jsonPath("$.createdAt", notNullValue()));
     }
 
+    @Test
+    @DirtiesContext
+    void create_whenImageDoesNotBelongToLoggedInUser_thenReturnBadRequest() throws Exception {
+        // given
+        User loggedInUser = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.spotify, "user-123");
+        User fileOwner = new User("234", "simon@chipmunks.de", "simon", "/path/to/image", Provider.spotify, "user-234");
+        this.userRepository.save(loggedInUser);
+
+        OAuth2User oAuth2User = new DefaultOAuth2User(null, Map.of(
+                "email", loggedInUser.getEmail()
+        ), "email");
+
+        MockMultipartFile file = new MockMultipartFile("file", "file.txt", "text/plain", "some image".getBytes());
+        File uploadedFile = this.fileService.saveFileForUser(file, fileOwner);
+
+        String givenJson = String.format("""
+                {
+                    "title": "Best mixtape ever",
+                    "description": "some nice description",
+                    "image": "%s"
+                }
+                """, uploadedFile.getId());
+
+        // when + then
+        this.mvc.perform(post("/api/mixtapes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(givenJson)
+                        .with(oauth2Login().oauth2User(oAuth2User))
+                )
+                .andExpect(status().isBadRequest());
+    }
+
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -46,6 +46,18 @@ class MixtapeControllerTest {
     @DirtiesContext
     void create_whenLoggedIn_thenReturnMixtape() throws Exception {
         // given
+        String expectedJson = """
+                {
+                    "title": "Best mixtape ever",
+                    "description": "some nice description",
+                    "createdBy": {
+                        "id": "123",
+                        "name": "alvin",
+                        "imageUrl": "/path/to/image"
+                    }
+                }
+                """;
+
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.spotify, "user-123");
         this.userRepository.save(user);
 
@@ -63,19 +75,6 @@ class MixtapeControllerTest {
                     "image": "%s"
                 }
                 """, uploadedFile.getId());
-
-        String expectedJson = String.format("""
-                {
-                    "title": "Best mixtape ever",
-                    "description": "some nice description",
-                    "image": "%s",
-                    "createdBy": {
-                        "id": "%s",
-                        "name": "%s",
-                        "imageUrl": "%s"
-                    }
-                }
-                """, uploadedFile.getId(), user.getId(), user.getName(), user.getImageUrl());
 
         // when + then
         this.mvc.perform(post("/api/mixtapes")

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -69,9 +69,13 @@ class MixtapeControllerTest {
                     "title": "Best mixtape ever",
                     "description": "some nice description",
                     "image": "%s",
-                    "createdBy": "%s"
+                    "createdBy": {
+                        "id": "%s",
+                        "name": "%s",
+                        "imageUrl": "%s"
+                    }
                 }
-                """, uploadedFile.getId(), user.getId());
+                """, uploadedFile.getId(), user.getId(), user.getName(), user.getImageUrl());
 
         // when + then
         this.mvc.perform(post("/api/mixtapes")

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -1,0 +1,88 @@
+package com.github.chuettenrauch.mixifyapi.integration.mixtape.controller;
+
+import com.github.chuettenrauch.mixifyapi.file.model.File;
+import com.github.chuettenrauch.mixifyapi.file.service.FileService;
+import com.github.chuettenrauch.mixifyapi.user.model.Provider;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MixtapeControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FileService fileService;
+
+    @Test
+    void create_whenNotLoggedIn_thenReturnUnauthorized() throws Exception {
+        this.mvc.perform(post("/api/mixtapes"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DirtiesContext
+    void create_whenLoggedIn_thenReturnMixtape() throws Exception {
+        // given
+        User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.spotify, "user-123");
+        this.userRepository.save(user);
+
+        OAuth2User oAuth2User = new DefaultOAuth2User(null, Map.of(
+                "email", user.getEmail()
+        ), "email");
+
+        MockMultipartFile file = new MockMultipartFile("file", "file.txt", "text/plain", "some image".getBytes());
+        File uploadedFile = this.fileService.saveFileForUser(file, user);
+
+        String givenJson = String.format("""
+                {
+                    "title": "Best mixtape ever",
+                    "description": "some nice description",
+                    "image": "%s"
+                }
+                """, uploadedFile.getId());
+
+        String expectedJson = String.format("""
+                {
+                    "title": "Best mixtape ever",
+                    "description": "some nice description",
+                    "image": "%s",
+                    "createdBy": "%s"
+                }
+                """, uploadedFile.getId(), user.getId());
+
+        // when + then
+        this.mvc.perform(post("/api/mixtapes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(givenJson)
+                        .with(oauth2Login().oauth2User(oAuth2User))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(content().json(expectedJson))
+                .andExpect(jsonPath("$.id", notNullValue()))
+                .andExpect(jsonPath("$.createdAt", notNullValue()));
+    }
+
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/audit/provider/AuditorProviderTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/audit/provider/AuditorProviderTest.java
@@ -1,5 +1,6 @@
-package com.github.chuettenrauch.mixifyapi.audit.provider;
+package com.github.chuettenrauch.mixifyapi.unit.audit.provider;
 
+import com.github.chuettenrauch.mixifyapi.audit.provider.AuditorProvider;
 import com.github.chuettenrauch.mixifyapi.user.model.User;
 import com.github.chuettenrauch.mixifyapi.user.service.UserService;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/audit/provider/AuditorProviderTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/audit/provider/AuditorProviderTest.java
@@ -24,11 +24,11 @@ class AuditorProviderTest {
 
         // when
         AuditorProvider sut = new AuditorProvider(userService);
-        Optional<String> actual = sut.getCurrentAuditor();
+        Optional<User> actual = sut.getCurrentAuditor();
 
         // then
         assertTrue(actual.isPresent());
-        assertEquals(user.getId(), actual.get());
+        assertEquals(user, actual.get());
     }
 
     @Test
@@ -39,7 +39,7 @@ class AuditorProviderTest {
 
         // when
         AuditorProvider sut = new AuditorProvider(userService);
-        Optional<String> actual = sut.getCurrentAuditor();
+        Optional<User> actual = sut.getCurrentAuditor();
 
         // then
         assertTrue(actual.isEmpty());

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/file/validation/validator/IsOwnedByAuthenticatedUserValidatorTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/file/validation/validator/IsOwnedByAuthenticatedUserValidatorTest.java
@@ -1,0 +1,80 @@
+package com.github.chuettenrauch.mixifyapi.unit.file.validation.validator;
+
+import com.github.chuettenrauch.mixifyapi.file.exception.FileNotFoundException;
+import com.github.chuettenrauch.mixifyapi.file.model.File;
+import com.github.chuettenrauch.mixifyapi.file.service.FileService;
+import com.github.chuettenrauch.mixifyapi.file.validation.validator.IsOwnedByAuthenticatedUserValidator;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IsOwnedByAuthenticatedUserValidatorTest {
+
+    @Test
+    void isValid_whenNotLoggedIn_thenReturnFalse() {
+        // given
+        FileService fileService = mock(FileService.class);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
+
+        // when
+        IsOwnedByAuthenticatedUserValidator sut = new IsOwnedByAuthenticatedUserValidator(fileService, userService);
+        boolean actual = sut.isValid("123", null);
+
+        // then
+        assertFalse(actual);
+    }
+
+    @Test
+    void isValid_whenLoggedInButFileNotFound_thenReturnFalse() throws IOException {
+        // given
+        String fileId = "file-1";
+
+        User authenticatedUser = new User();
+        authenticatedUser.setId("123");
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(authenticatedUser));
+
+        FileService fileService = mock(FileService.class);
+        when(fileService.findFileByIdForUser(fileId, authenticatedUser)).thenThrow(FileNotFoundException.class);
+
+        // when
+        IsOwnedByAuthenticatedUserValidator sut = new IsOwnedByAuthenticatedUserValidator(fileService, userService);
+        boolean actual = sut.isValid(fileId, null);
+
+        // then
+        assertFalse(actual);
+    }
+
+    @Test
+    void isValid_whenLoggedInAndFileFound_thenReturnTrue() throws IOException {
+        // given
+        String fileId = "file-1";
+
+        User authenticatedUser = new User();
+        authenticatedUser.setId("123");
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(authenticatedUser));
+
+        FileService fileService = mock(FileService.class);
+        when(fileService.findFileByIdForUser(fileId, authenticatedUser)).thenReturn(mock(File.class));
+
+        // when
+        IsOwnedByAuthenticatedUserValidator sut = new IsOwnedByAuthenticatedUserValidator(fileService, userService);
+        boolean actual = sut.isValid(fileId, null);
+
+        // then
+        assertTrue(actual);
+    }
+
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
@@ -1,0 +1,29 @@
+package com.github.chuettenrauch.mixifyapi.unit.mixtape.service;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.repository.MixtapeRepository;
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MixtapeServiceTest {
+
+    @Test
+    void save_delegatesToMixtapeRepository() {
+        // given
+        Mixtape expected = new Mixtape();
+
+        MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
+        when(mixtapeRepository.save(expected)).thenReturn(expected);
+
+        // when
+        MixtapeService sut = new MixtapeService(mixtapeRepository);
+        Mixtape actual = sut.save(expected);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeRepository).save(expected);
+    }
+}


### PR DESCRIPTION
- `POST /api/mixtapes` endpoint
- enabled mongo auditing, that automatically sets createdBy and createdAt on mixtape (see https://medium.com/codex/spring-data-mongodb-auditing-b4a874442a6) 
- added validation to check, that given image ID belongs to a file, that the same user had uploaded (see https://www.baeldung.com/spring-mvc-custom-validator)
- excluded sonar rule "Replace this persistent entity with a simple POJO or DTO object."
