### PR TITLE
GH-34 mixtape form

### DIFF
--- a/frontend/src/api/mixify-api.ts
+++ b/frontend/src/api/mixify-api.ts
@@ -1,6 +1,8 @@
 import User from "../types/user";
 import axios from "axios";
 import Mixtape from "../types/mixtape";
+import Form from "../types/forms";
+import FileMetadata from "../types/file-metadata";
 
 export namespace UserApi {
     const client = axios.create({
@@ -25,6 +27,27 @@ export namespace MixtapeApi {
 
     export async function getMixtapes(): Promise<Mixtape[]> {
         const response = await client.get("");
+
+        return response.data;
+    }
+
+    export async function createMixtape(mixtapeForm: Form.Mixtape): Promise<Mixtape> {
+        const response = await client.post("", mixtapeForm);
+
+        return response.data;
+    }
+}
+
+export namespace FileApi {
+    const client = axios.create({
+        baseURL: "/api/files"
+    })
+
+    export async function uploadFile(file: File): Promise<FileMetadata> {
+        const formData: FormData = new FormData();
+        formData.set("file", file);
+
+        const response = await client.post("", formData);
 
         return response.data;
     }

--- a/frontend/src/components/FormHeader.tsx
+++ b/frontend/src/components/FormHeader.tsx
@@ -1,0 +1,17 @@
+import {Container, IconButton, Typography} from "@mui/material";
+import {Close as CloseIcon} from "@mui/icons-material";
+import React from "react";
+
+export default function FormHeader({title, onClose}: {
+    title: string,
+    onClose: () => void,
+}) {
+    return (
+        <Container sx={{display: "flex", justifyContent: "center", p: 0, position: "relative"}}>
+            <IconButton sx={{position: "absolute", top: 0, right: 0}} onClick={() => onClose()}>
+                <CloseIcon/>
+            </IconButton>
+            <Typography variant="h1" component="h1" textTransform={"uppercase"}>{title}</Typography>
+        </Container>
+    )
+}

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -1,6 +1,6 @@
 import {Container, IconButton, Skeleton, Stack} from "@mui/material";
 import {PhotoCamera as PhotoCameraIcon} from "@mui/icons-material";
-import React, {ChangeEvent, useState} from "react";
+import React, {ChangeEvent, useMemo, useState} from "react";
 import FileMetadata from "../types/file-metadata";
 import {FileApi} from "../api/mixify-api";
 
@@ -9,6 +9,15 @@ export default function ImageUpload({imageUrl = null, onUpload}: {
     onUpload: (fileMetadata: FileMetadata) => void,
 }) {
     const [imagePreview, setImagePreview] = useState<string | null>(imageUrl ?? null);
+
+    const fileReader: FileReader = useMemo<FileReader>(() => {
+        const reader = new FileReader();
+        reader.addEventListener("load", () => {
+            setImagePreview(reader.result as string);
+        }, false);
+
+        return reader;
+    }, []);
 
     const onImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
         const {files} = e.target;
@@ -20,14 +29,16 @@ export default function ImageUpload({imageUrl = null, onUpload}: {
 
         const fileToUpload: File = files[0];
 
-        const reader = new FileReader();
-        reader.addEventListener("load", () => {
-            setImagePreview(reader.result as string);
-        }, false);
+        showImagePreview(fileToUpload);
+        uploadFile(fileToUpload);
+    }
 
-        reader.readAsDataURL(fileToUpload);
+    const showImagePreview = (file: File) => {
+        fileReader.readAsDataURL(file);
+    }
 
-        const fileMetadata: FileMetadata = await FileApi.uploadFile(fileToUpload);
+    const uploadFile = async (file: File) => {
+        const fileMetadata: FileMetadata = await FileApi.uploadFile(file);
 
         onUpload(fileMetadata);
     }

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -48,6 +48,7 @@ export default function ImageUpload({imageUrl = null, onUpload}: {
             spacing={2}
             width="100%"
             maxWidth={(theme) => theme.breakpoints.values.sm}
+            sx={{position: "relative"}}
         >
             <Container sx={{height: 0, overflow: "hidden", paddingTop: "100%", position: "relative"}}>
                 {imagePreview
@@ -68,9 +69,18 @@ export default function ImageUpload({imageUrl = null, onUpload}: {
                 }
             </Container>
 
-            <IconButton aria-label="upload image" component="label" sx={{zIndex: 1}}>
+            <IconButton size="large" aria-label="upload image" component="label" sx={{
+                display: "block",
+                m: 0,
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                height: "100%",
+                zIndex: 1
+            }}>
                 <input hidden accept="image/*" type="file" onChange={onImageChange}/>
-                <PhotoCameraIcon/>
+                <PhotoCameraIcon sx={{width: "30%", height: "100%"}}/>
             </IconButton>
         </Stack>
     );

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -1,0 +1,65 @@
+import {Container, IconButton, Skeleton, Stack} from "@mui/material";
+import {PhotoCamera as PhotoCameraIcon} from "@mui/icons-material";
+import React, {ChangeEvent, useState} from "react";
+import FileMetadata from "../types/file-metadata";
+import {FileApi} from "../api/mixify-api";
+
+export default function ImageUpload({onUpload}: {
+    onUpload: (fileMetadata: FileMetadata) => void,
+}) {
+    const [imagePreview, setImagePreview] = useState<string | null>(null);
+
+    const onImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
+        const {files} = e.target;
+
+        if (!files || files.length === 0) {
+            setImagePreview(null);
+            return;
+        }
+
+        const fileToUpload: File = files[0];
+
+        const reader = new FileReader();
+        reader.addEventListener("load", () => {
+            setImagePreview(reader.result as string);
+        }, false);
+
+        reader.readAsDataURL(fileToUpload);
+
+        const fileMetadata: FileMetadata = await FileApi.uploadFile(fileToUpload);
+
+        onUpload(fileMetadata);
+    }
+
+    return (
+        <Stack
+            spacing={2}
+            width="100%"
+            maxWidth={(theme) => theme.breakpoints.values.sm}
+        >
+            <Container sx={{height: 0, overflow: "hidden", paddingTop: "100%", position: "relative"}}>
+                {imagePreview
+                    ? <img src={imagePreview} alt="preview" style={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        objectFit: "cover",
+                        width: "100%",
+                        height: "100%"}}
+                    />
+                    : <Skeleton variant="rectangular" animation={false} width="100%" height="100%" sx={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                    }}/>
+
+                }
+            </Container>
+
+            <IconButton aria-label="upload image" component="label" sx={{zIndex: 1}}>
+                <input hidden accept="image/*" type="file" onChange={onImageChange}/>
+                <PhotoCameraIcon/>
+            </IconButton>
+        </Stack>
+    );
+}

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -4,10 +4,11 @@ import React, {ChangeEvent, useState} from "react";
 import FileMetadata from "../types/file-metadata";
 import {FileApi} from "../api/mixify-api";
 
-export default function ImageUpload({onUpload}: {
+export default function ImageUpload({imageUrl = null, onUpload}: {
+    imageUrl: string|null,
     onUpload: (fileMetadata: FileMetadata) => void,
 }) {
-    const [imagePreview, setImagePreview] = useState<string | null>(null);
+    const [imagePreview, setImagePreview] = useState<string | null>(imageUrl ?? null);
 
     const onImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
         const {files} = e.target;

--- a/frontend/src/components/MixtapeCard.tsx
+++ b/frontend/src/components/MixtapeCard.tsx
@@ -10,16 +10,30 @@ import {
     Typography
 } from "@mui/material";
 import {Close as CloseIcon, Edit as EditIcon, MoreVert as MoreVertIcon} from "@mui/icons-material";
-import React from "react";
+import React, {useState} from "react";
 import MixtapeUtils from "../utils/mixtape-utils";
+import MixtapeForm from "./MixtapeForm";
 
 export default function MixtapeCard({mixtape}: {
     mixtape: Mixtape
 }) {
     const [mixtapeMenu, setMixtapeMenu] = React.useState<null | HTMLElement>(null);
+    const [isMixtapeFormOpen, setIsMixtapeFormOpen] = useState(false);
 
     const mixtapeMenuId = `mixtape-${mixtape.id}-menu`;
     const mixtapeMenuOpen = Boolean(mixtapeMenu);
+
+    const openMixtapeForm = () => {
+        setIsMixtapeFormOpen(true);
+    }
+
+    const closeMixtapeForm= () => {
+        setIsMixtapeFormOpen(false);
+    }
+
+    const editMixtape = (savedMixtape: Mixtape) => {
+        console.log(savedMixtape);
+    }
 
     return (
         <Card elevation={5} sx={{display: "flex", position: "relative"}}>
@@ -63,7 +77,7 @@ export default function MixtapeCard({mixtape}: {
                     onClose={() => setMixtapeMenu(null)}
                     onClick={() => setMixtapeMenu(null)}
                 >
-                    <MenuItem>
+                    <MenuItem onClick={openMixtapeForm}>
                         <ListItemIcon>
                             <EditIcon fontSize="small"/>
                         </ListItemIcon>
@@ -77,6 +91,8 @@ export default function MixtapeCard({mixtape}: {
                     </MenuItem>
                 </Menu>
             </CardActions>
+
+            <MixtapeForm title="Edit mixtape" open={isMixtapeFormOpen} mixtape={mixtape} onSave={editMixtape} onClose={closeMixtapeForm}/>
             <Backdrop open={mixtapeMenuOpen} sx={{zIndex: (theme) => theme.zIndex.drawer + 1}}/>
         </Card>
     );

--- a/frontend/src/components/MixtapeCard.tsx
+++ b/frontend/src/components/MixtapeCard.tsx
@@ -14,8 +14,9 @@ import React, {useState} from "react";
 import MixtapeUtils from "../utils/mixtape-utils";
 import MixtapeForm from "./MixtapeForm";
 
-export default function MixtapeCard({mixtape}: {
-    mixtape: Mixtape
+export default function MixtapeCard({mixtape, onEdit}: {
+    mixtape: Mixtape,
+    onEdit: (savedMixtape: Mixtape) => void,
 }) {
     const [mixtapeMenu, setMixtapeMenu] = React.useState<null | HTMLElement>(null);
     const [isMixtapeFormOpen, setIsMixtapeFormOpen] = useState(false);
@@ -29,10 +30,6 @@ export default function MixtapeCard({mixtape}: {
 
     const closeMixtapeForm= () => {
         setIsMixtapeFormOpen(false);
-    }
-
-    const editMixtape = (savedMixtape: Mixtape) => {
-        console.log(savedMixtape);
     }
 
     return (
@@ -92,7 +89,7 @@ export default function MixtapeCard({mixtape}: {
                 </Menu>
             </CardActions>
 
-            <MixtapeForm title="Edit mixtape" open={isMixtapeFormOpen} mixtape={mixtape} onSave={editMixtape} onClose={closeMixtapeForm}/>
+            <MixtapeForm title="Edit mixtape" open={isMixtapeFormOpen} mixtape={mixtape} onSave={onEdit} onClose={closeMixtapeForm}/>
             <Backdrop open={mixtapeMenuOpen} sx={{zIndex: (theme) => theme.zIndex.drawer + 1}}/>
         </Card>
     );

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -1,6 +1,6 @@
-import {Container, IconButton, Modal, Typography} from "@mui/material";
-import {Close as CloseIcon} from "@mui/icons-material";
+import {Container, Modal} from "@mui/material";
 import React from "react";
+import FormHeader from "./FormHeader";
 
 export default function MixtapeForm({open, onClose}: {
     open: boolean
@@ -15,22 +15,13 @@ export default function MixtapeForm({open, onClose}: {
         >
             <Container sx={{
                 paddingInline: 2,
-                paddingBlock: 9,
+                paddingBlock: 10,
                 width: "100%",
                 height: "100vh",
                 bgcolor: 'background.paper',
                 position: "relative"
             }}>
-                <IconButton
-                    onClick={onClose}
-                    sx={{
-                        position: "absolute",
-                        top: (theme) => theme.spacing(8),
-                        right: (theme) => theme.spacing(1)
-                    }}>
-                    <CloseIcon/>
-                </IconButton>
-                <Typography variant="h1" component="h1" textTransform={"uppercase"}>Create Mixtape</Typography>
+                <FormHeader title="Create Mixtape" onClose={onClose}/>
             </Container>
         </Modal>
     );

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -14,9 +14,10 @@ const initialMixtapeData = {
     image: "",
 }
 
-export default function MixtapeForm({mixtape, open, onClose}: {
+export default function MixtapeForm({mixtape, open, onSave, onClose}: {
     mixtape?: Mixtape,
     open: boolean,
+    onSave: (savedMixtape: Mixtape) => void,
     onClose: () => void,
 }) {
     const [mixtapeForm, setMixtapeForm] = useState<Form.Mixtape>(mixtape ?? initialMixtapeData);
@@ -24,8 +25,8 @@ export default function MixtapeForm({mixtape, open, onClose}: {
     const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
-        await MixtapeApi.createMixtape(mixtapeForm);
-        onClose();
+        const mixtape: Mixtape = await MixtapeApi.createMixtape(mixtapeForm);
+        onSave(mixtape)
     };
 
     const onImageUpload = (fileMetadata: FileMetadata) => {

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -7,6 +7,7 @@ import {Save as SaveIcon} from "@mui/icons-material";
 import {MixtapeApi} from "../api/mixify-api";
 import FileMetadata from "../types/file-metadata";
 import ImageUpload from "./ImageUpload";
+import {toast} from "react-toastify";
 
 const initialMixtapeData = {
     title: "",
@@ -28,7 +29,11 @@ export default function MixtapeForm({title, mixtape, open, onSave, onClose}: {
 
         // @ToDo use PUT endpoint for update and setId to null on POST to ensure, that PUT endpoint is used
         const savedMixtape: Mixtape = await MixtapeApi.createMixtape(mixtapeForm);
-        onSave(savedMixtape)
+
+        onSave(savedMixtape);
+        onClose();
+
+        toast.success("Successfully saved mixtape.");
     };
 
     const onImageUpload = (fileMetadata: FileMetadata) => {

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -27,7 +27,6 @@ export default function MixtapeForm({title, mixtape, open, onSave, onClose}: {
     const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
-        // @ToDo use PUT endpoint for update and setId to null on POST to ensure, that PUT endpoint is used
         const savedMixtape: Mixtape = await MixtapeApi.createMixtape(mixtapeForm);
 
         onSave(savedMixtape);

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -1,11 +1,12 @@
-import {Button, Container, IconButton, Modal, Skeleton, Stack, TextField} from "@mui/material";
+import {Button, Container, Modal, Stack, TextField} from "@mui/material";
 import React, {ChangeEvent, FormEvent, useState} from "react";
 import FormHeader from "./FormHeader";
 import Form from "../types/forms";
 import Mixtape from "../types/mixtape";
-import {PhotoCamera as PhotoCameraIcon, Save as SaveIcon} from "@mui/icons-material";
-import {FileApi, MixtapeApi} from "../api/mixify-api";
+import {Save as SaveIcon} from "@mui/icons-material";
+import {MixtapeApi} from "../api/mixify-api";
 import FileMetadata from "../types/file-metadata";
+import ImageUpload from "./ImageUpload";
 
 const initialMixtapeData = {
     title: "",
@@ -20,8 +21,6 @@ export default function MixtapeForm({mixtape, open, onClose}: {
 }) {
     const [mixtapeForm, setMixtapeForm] = useState<Form.Mixtape>(mixtape ?? initialMixtapeData);
 
-    const [imagePreview, setImagePreview] = useState<string | null>(null);
-
     const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
@@ -29,31 +28,14 @@ export default function MixtapeForm({mixtape, open, onClose}: {
         onClose();
     };
 
-    const onImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
-        const {files} = e.target;
-        if (!files || files.length === 0) {
-            setImagePreview(null);
-            return;
-        }
-
-        const fileToUpload: File = files[0];
-
-        const reader = new FileReader();
-        reader.addEventListener("load", () => {
-            setImagePreview(reader.result as string);
-        }, false);
-
-        reader.readAsDataURL(fileToUpload);
-
-        const metadata: FileMetadata = await FileApi.uploadFile(fileToUpload);
-
+    const onImageUpload = (fileMetadata: FileMetadata) => {
         setMixtapeForm({
             ...mixtapeForm,
-            image: metadata.id
+            image: fileMetadata.id
         });
     }
 
-    const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
         const {name, value} = e.target;
 
         setMixtapeForm({
@@ -83,35 +65,7 @@ export default function MixtapeForm({mixtape, open, onClose}: {
             }}>
                 <FormHeader title="Create Mixtape" onClose={onClose}/>
 
-                <Stack
-                    spacing={2}
-                    width="100%"
-                    maxWidth={(theme) => theme.breakpoints.values.sm}
-                >
-                    <Container sx={{height: 0, overflow: "hidden", paddingTop: "100%", position: "relative"}}>
-                        {imagePreview
-                            ? <img src={imagePreview} alt="preview" style={{
-                                position: "absolute",
-                                top: 0,
-                                left: 0,
-                                objectFit: "cover",
-                                width: "100%",
-                                height: "100%"}}
-                            />
-                            : <Skeleton variant="rectangular" animation={false} width="100%" height="100%" sx={{
-                                position: "absolute",
-                                top: 0,
-                                left: 0,
-                            }}/>
-
-                        }
-                    </Container>
-
-                    <IconButton aria-label="upload image" component="label" sx={{zIndex: 1}}>
-                        <input hidden accept="image/*" type="file" onChange={onImageChange}/>
-                        <PhotoCameraIcon/>
-                    </IconButton>
-                </Stack>
+                <ImageUpload onUpload={onImageUpload}/>
 
                 <Stack
                     component="form"
@@ -138,7 +92,7 @@ export default function MixtapeForm({mixtape, open, onClose}: {
                         label="Title"
                         placeholder="Mixtape title"
                         margin="normal"
-                        onChange={onChange}
+                        onChange={onInputChange}
                     />
                     <TextField
                         required
@@ -150,7 +104,7 @@ export default function MixtapeForm({mixtape, open, onClose}: {
                         label="Description"
                         placeholder="What is your mixtape about..."
                         margin="normal"
-                        onChange={onChange}
+                        onChange={onInputChange}
                     />
                     <Button type="submit" variant="contained" startIcon={<SaveIcon/>}>
                         Save

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -60,6 +60,7 @@ export default function MixtapeForm({title, mixtape, open, onSave, onClose}: {
                 alignItems: "center",
                 paddingInline: 2,
                 paddingBlock: {xs: 9, sm: 10},
+                gap: 2,
                 width: "100%",
                 height: "100vh",
                 bgcolor: 'background.paper',
@@ -77,15 +78,6 @@ export default function MixtapeForm({title, mixtape, open, onSave, onClose}: {
                     maxWidth={(theme) => theme.breakpoints.values.sm}
                     onSubmit={onSubmit}
                 >
-                    <input
-                        required
-                        readOnly
-                        hidden
-                        id="image"
-                        name="image"
-                        value={mixtapeForm.image}
-                    />
-
                     <TextField
                         required
                         variant="standard"
@@ -94,7 +86,6 @@ export default function MixtapeForm({title, mixtape, open, onSave, onClose}: {
                         value={mixtapeForm.title}
                         label="Title"
                         placeholder="Mixtape title"
-                        margin="normal"
                         onChange={onInputChange}
                     />
                     <TextField
@@ -109,6 +100,15 @@ export default function MixtapeForm({title, mixtape, open, onSave, onClose}: {
                         margin="normal"
                         onChange={onInputChange}
                     />
+                    <input
+                        required
+                        readOnly
+                        hidden
+                        id="image"
+                        name="image"
+                        value={mixtapeForm.image}
+                    />
+
                     <Button type="submit" variant="contained" startIcon={<SaveIcon/>}>
                         Save
                     </Button>

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -26,8 +26,9 @@ export default function MixtapeForm({title, mixtape, open, onSave, onClose}: {
     const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
-        const mixtape: Mixtape = await MixtapeApi.createMixtape(mixtapeForm);
-        onSave(mixtape)
+        // @ToDo use PUT endpoint for update and setId to null on POST to ensure, that PUT endpoint is used
+        const savedMixtape: Mixtape = await MixtapeApi.createMixtape(mixtapeForm);
+        onSave(savedMixtape)
     };
 
     const onImageUpload = (fileMetadata: FileMetadata) => {

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -1,11 +1,38 @@
-import {Container, Modal} from "@mui/material";
-import React from "react";
+import {Button, Container, Modal, Stack, TextField} from "@mui/material";
+import React, {ChangeEvent, FormEvent, useState} from "react";
 import FormHeader from "./FormHeader";
+import Form from "../types/forms";
+import Mixtape from "../types/mixtape";
+import {Save as SaveIcon} from "@mui/icons-material";
 
-export default function MixtapeForm({open, onClose}: {
-    open: boolean
+const initialMixtapeData = {
+    title: "",
+    description: "",
+    image: "",
+}
+
+export default function MixtapeForm({mixtape, open, onClose}: {
+    mixtape?: Mixtape,
+    open: boolean,
     onClose: () => void,
 }) {
+    const [mixtapeForm, setMixtapeForm] = useState<Form.Mixtape>(mixtape ?? initialMixtapeData);
+
+    const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+
+        console.log(mixtapeForm);
+    };
+
+    const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const {name, value} = e.target;
+
+        setMixtapeForm({
+            ...mixtapeForm,
+            [name]: value
+        });
+    };
+
     return (
         <Modal
             open={open}
@@ -14,14 +41,58 @@ export default function MixtapeForm({open, onClose}: {
             sx={{overflow: "scroll", zIndex: (theme) => theme.zIndex.appBar - 2}}
         >
             <Container sx={{
+                display: "flex", flexDirection: "column", alignItems: "center",
                 paddingInline: 2,
-                paddingBlock: 10,
+                paddingBlock: {xs: 9, sm: 10},
                 width: "100%",
                 height: "100vh",
                 bgcolor: 'background.paper',
                 position: "relative"
             }}>
                 <FormHeader title="Create Mixtape" onClose={onClose}/>
+
+                <Stack
+                    component="form"
+                    spacing={2}
+                    width="100%"
+                    maxWidth={(theme) => theme.breakpoints.values.sm}
+                    onSubmit={onSubmit}
+                >
+                    <input
+                        required
+                        hidden
+                        readOnly
+                        id="image"
+                        name="image"
+                        value={mixtapeForm.image}
+                    />
+                    <TextField
+                        required
+                        variant="standard"
+                        id="title"
+                        name="title"
+                        value={mixtapeForm.title}
+                        label="Title"
+                        placeholder="Mixtape title"
+                        margin="normal"
+                        onChange={onChange}
+                    />
+                    <TextField
+                        required
+                        multiline
+                        rows={6}
+                        id="description"
+                        name="description"
+                        value={mixtapeForm.description}
+                        label="Description"
+                        placeholder="What is your mixtape about..."
+                        margin="normal"
+                        onChange={onChange}
+                    />
+                    <Button type="submit" variant="contained" startIcon={<SaveIcon/>}>
+                        Save
+                    </Button>
+                </Stack>
             </Container>
         </Modal>
     );

--- a/frontend/src/components/MixtapeForm.tsx
+++ b/frontend/src/components/MixtapeForm.tsx
@@ -14,7 +14,8 @@ const initialMixtapeData = {
     image: "",
 }
 
-export default function MixtapeForm({mixtape, open, onSave, onClose}: {
+export default function MixtapeForm({title, mixtape, open, onSave, onClose}: {
+    title: string,
     mixtape?: Mixtape,
     open: boolean,
     onSave: (savedMixtape: Mixtape) => void,
@@ -64,9 +65,9 @@ export default function MixtapeForm({mixtape, open, onSave, onClose}: {
                 position: "relative",
                 overflow: "scroll"
             }}>
-                <FormHeader title="Create Mixtape" onClose={onClose}/>
+                <FormHeader title={title} onClose={onClose}/>
 
-                <ImageUpload onUpload={onImageUpload}/>
+                <ImageUpload imageUrl={mixtape ? `/api/files/${mixtape.image}` : null} onUpload={onImageUpload}/>
 
                 <Stack
                     component="form"

--- a/frontend/src/pages/MixtapesOverviewPage.tsx
+++ b/frontend/src/pages/MixtapesOverviewPage.tsx
@@ -6,9 +6,11 @@ import MixtapeForm from "../components/MixtapeForm";
 import useMixtapes from "../hooks/useMixtapes";
 import PageHeader from "../components/PageHeader";
 import Mixtape from "../types/mixtape";
+import {useNavigate} from "react-router-dom";
 
 export default function MixtapesOverviewPage() {
-    const [mixtapes, setMixtapes] = useMixtapes();
+    const navigate = useNavigate();
+    const [mixtapes] = useMixtapes();
     const [isMixtapeFormOpen, setIsMixtapeFormOpen] = useState(false);
 
     const openMixtapeForm = () => {
@@ -19,12 +21,8 @@ export default function MixtapesOverviewPage() {
         setIsMixtapeFormOpen(false);
     }
 
-    const addMixtape = (mixtape: Mixtape) => {
-        setMixtapes([...mixtapes, mixtape]);
-    }
-
-    const editMixtape = (editedMixtape: Mixtape) => {
-        setMixtapes(mixtapes.map(m => m.id === editedMixtape.id ? editedMixtape : m))
+    const navigateToMixtapeDetailPage = (mixtape: Mixtape) => {
+        navigate(`/mixtapes/${mixtape.id}`);
     }
 
     return (
@@ -39,7 +37,7 @@ export default function MixtapesOverviewPage() {
 
             <Stack spacing={2} sx={{width: "100%"}}>
                 {mixtapes.map(mixtape => (
-                    <MixtapeCard key={mixtape.id} mixtape={mixtape} onEdit={editMixtape}/>
+                    <MixtapeCard key={mixtape.id} mixtape={mixtape} onEdit={navigateToMixtapeDetailPage}/>
                 ))}
             </Stack>
 
@@ -51,7 +49,7 @@ export default function MixtapesOverviewPage() {
                 <AddIcon/>
             </Fab>
 
-            <MixtapeForm title="Create mixtape" open={isMixtapeFormOpen} onSave={addMixtape} onClose={closeMixtapeForm}/>
+            <MixtapeForm title="Create mixtape" open={isMixtapeFormOpen} onSave={navigateToMixtapeDetailPage} onClose={closeMixtapeForm}/>
         </Container>
     );
 }

--- a/frontend/src/pages/MixtapesOverviewPage.tsx
+++ b/frontend/src/pages/MixtapesOverviewPage.tsx
@@ -5,9 +5,10 @@ import {Add as AddIcon} from "@mui/icons-material";
 import MixtapeForm from "../components/MixtapeForm";
 import useMixtapes from "../hooks/useMixtapes";
 import PageHeader from "../components/PageHeader";
+import Mixtape from "../types/mixtape";
 
 export default function MixtapesOverviewPage() {
-    const [mixtapes] = useMixtapes();
+    const [mixtapes, setMixtapes] = useMixtapes();
     const [isMixtapeFormOpen, setIsMixtapeFormOpen] = useState(false);
 
     const openMixtapeForm = () => {
@@ -16,6 +17,11 @@ export default function MixtapesOverviewPage() {
 
     const closeMixtapeForm= () => {
         setIsMixtapeFormOpen(false);
+    }
+
+    const addMixtape = (savedMixtape: Mixtape) => {
+        setMixtapes([...mixtapes, savedMixtape]);
+        closeMixtapeForm();
     }
 
     return (
@@ -42,7 +48,7 @@ export default function MixtapesOverviewPage() {
                 <AddIcon/>
             </Fab>
 
-            <MixtapeForm open={isMixtapeFormOpen} onClose={closeMixtapeForm}/>
+            <MixtapeForm open={isMixtapeFormOpen} onSave={addMixtape} onClose={closeMixtapeForm}/>
         </Container>
     );
 }

--- a/frontend/src/pages/MixtapesOverviewPage.tsx
+++ b/frontend/src/pages/MixtapesOverviewPage.tsx
@@ -48,7 +48,7 @@ export default function MixtapesOverviewPage() {
                 <AddIcon/>
             </Fab>
 
-            <MixtapeForm open={isMixtapeFormOpen} onSave={addMixtape} onClose={closeMixtapeForm}/>
+            <MixtapeForm title="Create mixtape" open={isMixtapeFormOpen} onSave={addMixtape} onClose={closeMixtapeForm}/>
         </Container>
     );
 }

--- a/frontend/src/pages/MixtapesOverviewPage.tsx
+++ b/frontend/src/pages/MixtapesOverviewPage.tsx
@@ -19,9 +19,12 @@ export default function MixtapesOverviewPage() {
         setIsMixtapeFormOpen(false);
     }
 
-    const addMixtape = (savedMixtape: Mixtape) => {
-        setMixtapes([...mixtapes, savedMixtape]);
-        closeMixtapeForm();
+    const addMixtape = (mixtape: Mixtape) => {
+        setMixtapes([...mixtapes, mixtape]);
+    }
+
+    const editMixtape = (editedMixtape: Mixtape) => {
+        setMixtapes(mixtapes.map(m => m.id === editedMixtape.id ? editedMixtape : m))
     }
 
     return (
@@ -36,7 +39,7 @@ export default function MixtapesOverviewPage() {
 
             <Stack spacing={2} sx={{width: "100%"}}>
                 {mixtapes.map(mixtape => (
-                    <MixtapeCard key={mixtape.id} mixtape={mixtape}/>
+                    <MixtapeCard key={mixtape.id} mixtape={mixtape} onEdit={editMixtape}/>
                 ))}
             </Stack>
 

--- a/frontend/src/types/file-metadata.ts
+++ b/frontend/src/types/file-metadata.ts
@@ -1,0 +1,5 @@
+type FileMetadata = {
+    id: string
+}
+
+export default FileMetadata;

--- a/frontend/src/types/forms.ts
+++ b/frontend/src/types/forms.ts
@@ -1,5 +1,6 @@
 namespace Form {
     export type Mixtape = {
+        id?: string,
         title: string,
         description: string,
         image: string,

--- a/frontend/src/types/forms.ts
+++ b/frontend/src/types/forms.ts
@@ -1,0 +1,9 @@
+namespace Form {
+    export type Mixtape = {
+        title: string,
+        description: string,
+        image: string,
+    }
+}
+
+export default Form;


### PR DESCRIPTION
- ImageUpload component that handles image upload and image preview
- Mixtape Form with functionality to upload image and save a mixtape 
- Mixtape Form is opened with "Create mixtape" title when "Create" Button clicked
- Mixtape Form is opened with "Edit mixtape" title and prefilled data when "Edit" is clicked (for editing the mixtape I temporarily use the POST endpoint - this will be changed, when PUT endpoint is implemented)
