### PR TITLE
GH-59 - DELETE endpoint for tracks

### DIFF
--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/TrackController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/TrackController.java
@@ -21,4 +21,9 @@ public class TrackController {
     public Track update(@PathVariable String mixtapeId, @PathVariable String id, @RequestBody Track track) {
         return this.trackService.updateByIdForMixtape(mixtapeId, id, track);
     }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable String mixtapeId, @PathVariable String id) {
+        this.trackService.deleteByIdForMixtape(mixtapeId, id);
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
@@ -42,7 +42,7 @@ public class Mixtape {
     public void removeTrackWithId(String id) {
         this.setTracks(this.getTracks()
                 .stream()
-                .filter(t -> t.getId() != null && !t.getId().equals(id))
+                .filter(t -> t.getId() == null || !t.getId().equals(id))
                 .toList()
         );
     }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
@@ -38,4 +38,12 @@ public class Mixtape {
                 .stream()
                 .anyMatch(t -> t.getId() != null && t.getId().equals(id));
     }
+
+    public void removeTrackWithId(String id) {
+        this.setTracks(this.getTracks()
+                .stream()
+                .filter(t -> t.getId() != null && !t.getId().equals(id))
+                .toList()
+        );
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
@@ -32,4 +32,10 @@ public class Mixtape {
     @CreatedBy
     @DocumentReference(lazy = true)
     private User createdBy;
+
+    public boolean hasTrackWithId(String id) {
+        return this.getTracks()
+                .stream()
+                .anyMatch(t -> t.getId() != null && t.getId().equals(id));
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/TrackService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/TrackService.java
@@ -27,13 +27,22 @@ public class TrackService {
 
     public Track updateByIdForMixtape(String mixtapeId, String id, Track track) {
         track.setId(id);
-        this.mixtapeService.findById(mixtapeId);
+        Mixtape mixtape = this.mixtapeService.findById(mixtapeId);
 
-        if (!this.trackRepository.existsById(track.getId())) {
+        if (!mixtape.hasTrackWithId(track.getId()) || !this.trackRepository.existsById(id)) {
             throw new NotFoundException();
         }
 
         return this.trackRepository.save(track);
     }
 
+    public void deleteByIdForMixtape(String mixtapeId, String id) {
+        Mixtape mixtape = this.mixtapeService.findById(mixtapeId);
+
+        if (!mixtape.hasTrackWithId(id) || !this.trackRepository.existsById(id)) {
+            throw new NotFoundException();
+        }
+
+        this.trackRepository.deleteById(id);
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/TrackService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/TrackService.java
@@ -44,5 +44,8 @@ public class TrackService {
         }
 
         this.trackRepository.deleteById(id);
+
+        mixtape.removeTrackWithId(id);
+        this.mixtapeService.updateById(mixtape.getId(), mixtape);
     }
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/model/MixtapeTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/model/MixtapeTest.java
@@ -100,13 +100,36 @@ class MixtapeTest {
         Track track = new Track();
         track.setId("123");
 
-        List<Track> expected = List.of(track);
+        Track otherTrack = new Track();
+        otherTrack.setId("123");
+
+        List<Track> expected = List.of(otherTrack, track);
 
         // when
         Mixtape sut = new Mixtape();
         sut.setTracks(expected);
 
         sut.removeTrackWithId("some-other-id");
+
+        // then
+        List<Track> actual = sut.getTracks();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void removeTrackWithId_whenTrackHasNoId_thenKeepTracksAsBefore() {
+        // given
+        Track track = new Track();
+        Track otherTrack = new Track();
+
+        List<Track> expected = List.of(otherTrack, track);
+
+        // when
+        Mixtape sut = new Mixtape();
+        sut.setTracks(expected);
+
+        sut.removeTrackWithId("some-id");
 
         // then
         List<Track> actual = sut.getTracks();

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/model/MixtapeTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/model/MixtapeTest.java
@@ -1,0 +1,72 @@
+package com.github.chuettenrauch.mixifyapi.unit.mixtape.model;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Track;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MixtapeTest {
+
+    @Test
+    void hasTrackWithId_whenMixtapeHasTrack_thenReturnTrue() {
+        // given
+        Track track = new Track();
+        track.setId("123");
+
+        Track otherTrack = new Track();
+        otherTrack.setId("234");
+
+        // when
+        Mixtape sut = new Mixtape();
+        sut.setTracks(List.of(otherTrack, track));
+
+        boolean actual = sut.hasTrackWithId("123");
+
+        // then
+        assertTrue(actual);
+    }
+
+    @Test
+    void hasTrackWithId_whenMixtapeDoesNotHaveTrack_thenReturnFalse() {
+        // given
+        Track track = new Track();
+        track.setId("123");
+
+        // when
+        Mixtape sut = new Mixtape();
+        sut.setTracks(List.of(track));
+
+        boolean actual = sut.hasTrackWithId("234");
+
+        // then
+        assertFalse(actual);
+    }
+
+    @Test
+    void hasTrackWithId_whenMixtapeDoesNotHaveAnyTracks_thenReturnFalse() {
+        // when
+        Mixtape sut = new Mixtape();
+        boolean actual = sut.hasTrackWithId("123");
+
+        // then
+        assertFalse(actual);
+    }
+
+    @Test
+    void hasTrackWithId_whenTrackDoesNotHaveId_thenReturnFalse() {
+        // given
+        Track track = new Track();
+
+        // when
+        Mixtape sut = new Mixtape();
+        sut.setTracks(List.of(track));
+
+        boolean actual = sut.hasTrackWithId("234");
+
+        // then
+        assertFalse(actual);
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/model/MixtapeTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/model/MixtapeTest.java
@@ -69,4 +69,48 @@ class MixtapeTest {
         // then
         assertFalse(actual);
     }
+
+    @Test
+    void removeTrackWithId_whenTrackExistsOnMixtape_thenRemoveTrackFromTracks() {
+        // given
+        Track track = new Track();
+        track.setId("123");
+
+        Track otherTrack = new Track();
+        otherTrack.setId("234");
+
+        List<Track> given = List.of(otherTrack, track);
+        List<Track> expected = List.of(otherTrack);
+
+        // when
+        Mixtape sut = new Mixtape();
+        sut.setTracks(given);
+
+        sut.removeTrackWithId(track.getId());
+
+        // then
+        List<Track> actual = sut.getTracks();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void removeTrackWithId_whenTrackDoesNotExistOnMixtape_thenKeepTracksAsBefore() {
+        // given
+        Track track = new Track();
+        track.setId("123");
+
+        List<Track> expected = List.of(track);
+
+        // when
+        Mixtape sut = new Mixtape();
+        sut.setTracks(expected);
+
+        sut.removeTrackWithId("some-other-id");
+
+        // then
+        List<Track> actual = sut.getTracks();
+
+        assertEquals(expected, actual);
+    }
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/TrackServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/TrackServiceTest.java
@@ -284,7 +284,7 @@ class TrackServiceTest {
     }
 
     @Test
-    void deleteByIdForMixtape_whenTrackExistsOnMixtape_thenDelete() {
+    void deleteByIdForMixtape_whenTrackExistsOnMixtape_thenDeleteAndUpdateMixtape() {
         // given
         Track track = new Track();
         track.setId("234");
@@ -305,5 +305,6 @@ class TrackServiceTest {
 
         // then
         verify(trackRepository).deleteById(track.getId());
+        verify(mixtapeService).updateById(mixtapeWithTrack.getId(), mixtapeWithTrack);
     }
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/TrackServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/TrackServiceTest.java
@@ -126,15 +126,18 @@ class TrackServiceTest {
     }
 
     @Test
-    void updateByIdForMixtape_whenTrackDoesNotExistOnMixtape_thenThrowNotFoundException() {
+    void updateByIdForMixtape_whenTrackDoesNotExist_thenThrowNotFoundException() {
         // given
         String mixtapeId = "123";
 
         Track track = new Track();
         track.setId("234");
 
+        Mixtape mixtapeWithTrack = new Mixtape();
+        mixtapeWithTrack.setTracks(List.of(track));
+
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenReturn(new Mixtape());
+        when(mixtapeService.findById(mixtapeId)).thenReturn(mixtapeWithTrack);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
         when(trackRepository.existsById(track.getId())).thenReturn(false);
@@ -148,9 +151,29 @@ class TrackServiceTest {
     }
 
     @Test
-    void updateByIdForMixtape_whenTrackExists_thenEnsureIdFromUrlAndSaveTrack() {
+    void updateByIdForMixtape_whenDoesNotExistOnMixtape_thenThrowNotFoundException() {
         // given
         String mixtapeId = "123";
+
+        Track track = new Track();
+        track.setId("234");
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(mixtapeId)).thenReturn(new Mixtape());
+
+        TrackRepository trackRepository = mock(TrackRepository.class);
+
+        // when
+        TrackService sut = new TrackService(trackRepository, mixtapeService);
+        assertThrows(NotFoundException.class, () -> sut.updateByIdForMixtape(mixtapeId, track.getId(), track));
+
+        // then
+        verify(trackRepository, never()).save(any());
+    }
+
+    @Test
+    void updateByIdForMixtape_whenTrackExistsOnMixtape_thenEnsureIdFromUrlAndSaveTrack() {
+        // given
         String trackIdFromUrl = "id-from-url";
 
         Track track = new Track();
@@ -159,8 +182,12 @@ class TrackServiceTest {
         Track expectedTrack = new Track();
         expectedTrack.setId(trackIdFromUrl);
 
+        Mixtape mixtapeWithTrack = new Mixtape();
+        mixtapeWithTrack.setId("123");
+        mixtapeWithTrack.setTracks(List.of(expectedTrack));
+
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenReturn(new Mixtape());
+        when(mixtapeService.findById(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
         when(trackRepository.existsById(trackIdFromUrl)).thenReturn(true);
@@ -168,10 +195,115 @@ class TrackServiceTest {
 
         // when
         TrackService sut = new TrackService(trackRepository, mixtapeService);
-        Track actual = sut.updateByIdForMixtape(mixtapeId, trackIdFromUrl, track);
+        Track actual = sut.updateByIdForMixtape(mixtapeWithTrack.getId(), trackIdFromUrl, track);
 
         // then
         assertEquals(expectedTrack, actual);
         verify(trackRepository).save(expectedTrack);
+    }
+
+    @Test
+    void deleteByIdForMixtape_whenNotLoggedIn_thenThrowUnauthorizedException() {
+        // given
+        String trackId = "234";
+        String mixtapeId = "123";
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(mixtapeId)).thenThrow(UnauthorizedException.class);
+
+        TrackRepository trackRepository = mock(TrackRepository.class);
+
+        // when
+        TrackService sut = new TrackService(trackRepository, mixtapeService);
+        assertThrows(UnauthorizedException.class, () -> sut.deleteByIdForMixtape(mixtapeId, trackId));
+
+        // then
+        verify(trackRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void deleteByIdForMixtape_whenMixtapeDoesNotExistOrDoesNotBelongToLoggedInUser_thenThrowNotFoundException() {
+        // given
+        String trackId = "234";
+        String mixtapeId = "123";
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(mixtapeId)).thenThrow(NotFoundException.class);
+
+        TrackRepository trackRepository = mock(TrackRepository.class);
+
+        // when
+        TrackService sut = new TrackService(trackRepository, mixtapeService);
+        assertThrows(NotFoundException.class, () -> sut.deleteByIdForMixtape(mixtapeId, trackId));
+
+        // then
+        verify(trackRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void deleteByIdForMixtape_whenTrackDoesNotExist_thenThrowNotFoundException() {
+        // given
+        Track track = new Track();
+        track.setId("234");
+
+        Mixtape mixtapeWithTrack = new Mixtape();
+        mixtapeWithTrack.setId("123");
+        mixtapeWithTrack.setTracks(List.of(track));
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
+
+        TrackRepository trackRepository = mock(TrackRepository.class);
+        when(trackRepository.existsById(track.getId())).thenReturn(false);
+
+        // when
+        TrackService sut = new TrackService(trackRepository, mixtapeService);
+        assertThrows(NotFoundException.class, () -> sut.deleteByIdForMixtape(mixtapeWithTrack.getId(), track.getId()));
+
+        // then
+        verify(trackRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void deleteByIdForMixtape_whenTrackDoesNotExistOnMixtape_thenThrowNotFoundException() {
+        // given
+        String trackId = "234";
+        String mixtapeId = "123";
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(mixtapeId)).thenReturn(new Mixtape());
+
+        TrackRepository trackRepository = mock(TrackRepository.class);
+
+        // when
+        TrackService sut = new TrackService(trackRepository, mixtapeService);
+        assertThrows(NotFoundException.class, () -> sut.deleteByIdForMixtape(mixtapeId, trackId));
+
+        // then
+        verify(trackRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void deleteByIdForMixtape_whenTrackExistsOnMixtape_thenDelete() {
+        // given
+        Track track = new Track();
+        track.setId("234");
+
+        Mixtape mixtapeWithTrack = new Mixtape();
+        mixtapeWithTrack.setId("123");
+        mixtapeWithTrack.setTracks(List.of(track));
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
+
+        TrackRepository trackRepository = mock(TrackRepository.class);
+        when(trackRepository.existsById(track.getId())).thenReturn(true);
+
+        // when
+        TrackService sut = new TrackService(trackRepository, mixtapeService);
+        sut.deleteByIdForMixtape(mixtapeWithTrack.getId(), track.getId());
+
+        // then
+        verify(trackRepository).deleteById(track.getId());
     }
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/TrackServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/TrackServiceTest.java
@@ -87,9 +87,10 @@ class TrackServiceTest {
     void updateByIdForMixtape_whenNotLoggedIn_thenThrowUnauthorizedException() {
         // given
         String mixtapeId = "123";
+        String trackId = "234";
 
         Track track = new Track();
-        track.setId("234");
+        track.setId(trackId);
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
         when(mixtapeService.findById(mixtapeId)).thenThrow(UnauthorizedException.class);
@@ -98,7 +99,7 @@ class TrackServiceTest {
 
         // when
         TrackService sut = new TrackService(trackRepository, mixtapeService);
-        assertThrows(UnauthorizedException.class, () -> sut.updateByIdForMixtape(mixtapeId, track.getId(), track));
+        assertThrows(UnauthorizedException.class, () -> sut.updateByIdForMixtape(mixtapeId, trackId, track));
 
         // then
         verify(trackRepository, never()).save(any());
@@ -108,9 +109,10 @@ class TrackServiceTest {
     void updateByIdForMixtape_whenMixtapeDoesNotExistOrDoesNotBelongToLoggedInUser_thenThrowNotFoundException() {
         // given
         String mixtapeId = "123";
+        String trackId = "234";
 
         Track track = new Track();
-        track.setId("234");
+        track.setId(trackId);
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
         when(mixtapeService.findById(mixtapeId)).thenThrow(NotFoundException.class);
@@ -119,7 +121,7 @@ class TrackServiceTest {
 
         // when
         TrackService sut = new TrackService(trackRepository, mixtapeService);
-        assertThrows(NotFoundException.class, () -> sut.updateByIdForMixtape(mixtapeId, track.getId(), track));
+        assertThrows(NotFoundException.class, () -> sut.updateByIdForMixtape(mixtapeId, trackId, track));
 
         // then
         verify(trackRepository, never()).save(any());
@@ -129,9 +131,10 @@ class TrackServiceTest {
     void updateByIdForMixtape_whenTrackDoesNotExist_thenThrowNotFoundException() {
         // given
         String mixtapeId = "123";
+        String trackId = "234";
 
         Track track = new Track();
-        track.setId("234");
+        track.setId(trackId);
 
         Mixtape mixtapeWithTrack = new Mixtape();
         mixtapeWithTrack.setTracks(List.of(track));
@@ -144,7 +147,7 @@ class TrackServiceTest {
 
         // when
         TrackService sut = new TrackService(trackRepository, mixtapeService);
-        assertThrows(NotFoundException.class, () -> sut.updateByIdForMixtape(mixtapeId, track.getId(), track));
+        assertThrows(NotFoundException.class, () -> sut.updateByIdForMixtape(mixtapeId, trackId, track));
 
         // then
         verify(trackRepository, never()).save(any());
@@ -154,9 +157,10 @@ class TrackServiceTest {
     void updateByIdForMixtape_whenDoesNotExistOnMixtape_thenThrowNotFoundException() {
         // given
         String mixtapeId = "123";
+        String trackId = "234";
 
         Track track = new Track();
-        track.setId("234");
+        track.setId(trackId);
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
         when(mixtapeService.findById(mixtapeId)).thenReturn(new Mixtape());
@@ -165,7 +169,7 @@ class TrackServiceTest {
 
         // when
         TrackService sut = new TrackService(trackRepository, mixtapeService);
-        assertThrows(NotFoundException.class, () -> sut.updateByIdForMixtape(mixtapeId, track.getId(), track));
+        assertThrows(NotFoundException.class, () -> sut.updateByIdForMixtape(mixtapeId, trackId, track));
 
         // then
         verify(trackRepository, never()).save(any());
@@ -243,11 +247,14 @@ class TrackServiceTest {
     @Test
     void deleteByIdForMixtape_whenTrackDoesNotExist_thenThrowNotFoundException() {
         // given
+        String trackId = "234";
+        String mixtapeId = "123";
+
         Track track = new Track();
-        track.setId("234");
+        track.setId(trackId);
 
         Mixtape mixtapeWithTrack = new Mixtape();
-        mixtapeWithTrack.setId("123");
+        mixtapeWithTrack.setId(mixtapeId);
         mixtapeWithTrack.setTracks(List.of(track));
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
@@ -258,7 +265,7 @@ class TrackServiceTest {
 
         // when
         TrackService sut = new TrackService(trackRepository, mixtapeService);
-        assertThrows(NotFoundException.class, () -> sut.deleteByIdForMixtape(mixtapeWithTrack.getId(), track.getId()));
+        assertThrows(NotFoundException.class, () -> sut.deleteByIdForMixtape(mixtapeId, trackId));
 
         // then
         verify(trackRepository, never()).deleteById(any());


### PR DESCRIPTION
- DELETE endpoint for track
- ensure, that track is also removed from mixtape
- bugfix: update was possible when track didn't belong to mixtape