### PR TITLE
GH-69 - flow to get to play mixtape page

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
             scope:
               - user-read-private
               - user-read-email
+              - user-read-playback-state
+              - user-modify-playback-state
+              - streaming
         provider:
           spotify:
             authorization-uri: https://accounts.spotify.com/authorize

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.7.0",
         "react-scripts": "5.0.1",
         "react-secure-storage": "^1.0.22",
+        "react-spotify-web-playback-sdk": "^3.0.1",
         "react-toastify": "^9.1.1",
         "typescript": "^4.9.4",
         "web-vitals": "^2.1.4"
@@ -4308,8 +4309,7 @@
     "node_modules/@types/spotify-web-playback-sdk": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/@types/spotify-web-playback-sdk/-/spotify-web-playback-sdk-0.1.15.tgz",
-      "integrity": "sha512-DBXmPajTtrm4Ykf2waHZAW6UR6Jqv8fKRTTDfXcSkse2VzF9uDdj7gb4mcwKMxdDrjJ4npy4EbnxH/xxuiKtoQ==",
-      "dev": true
+      "integrity": "sha512-DBXmPajTtrm4Ykf2waHZAW6UR6Jqv8fKRTTDfXcSkse2VzF9uDdj7gb4mcwKMxdDrjJ4npy4EbnxH/xxuiKtoQ=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -14784,6 +14784,22 @@
         "murmurhash-js": "^1.0.0"
       }
     },
+    "node_modules/react-spotify-web-playback-sdk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-spotify-web-playback-sdk/-/react-spotify-web-playback-sdk-3.0.1.tgz",
+      "integrity": "sha512-ubhP/SPiFq9ng25OdAOxfFNarraBRnGrFVHUGTbh0hxzSzUvteAtGHifqAsxrY3oWoOJ1vslll0Awg5YqYog/g==",
+      "dependencies": {
+        "@types/spotify-web-playback-sdk": "^0.1.12"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-toastify": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
@@ -20520,8 +20536,7 @@
     "@types/spotify-web-playback-sdk": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/@types/spotify-web-playback-sdk/-/spotify-web-playback-sdk-0.1.15.tgz",
-      "integrity": "sha512-DBXmPajTtrm4Ykf2waHZAW6UR6Jqv8fKRTTDfXcSkse2VzF9uDdj7gb4mcwKMxdDrjJ4npy4EbnxH/xxuiKtoQ==",
-      "dev": true
+      "integrity": "sha512-DBXmPajTtrm4Ykf2waHZAW6UR6Jqv8fKRTTDfXcSkse2VzF9uDdj7gb4mcwKMxdDrjJ4npy4EbnxH/xxuiKtoQ=="
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -27951,6 +27966,14 @@
       "requires": {
         "crypto-js": "^4.1.1",
         "murmurhash-js": "^1.0.0"
+      }
+    },
+    "react-spotify-web-playback-sdk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-spotify-web-playback-sdk/-/react-spotify-web-playback-sdk-3.0.1.tgz",
+      "integrity": "sha512-ubhP/SPiFq9ng25OdAOxfFNarraBRnGrFVHUGTbh0hxzSzUvteAtGHifqAsxrY3oWoOJ1vslll0Awg5YqYog/g==",
+      "requires": {
+        "@types/spotify-web-playback-sdk": "^0.1.12"
       }
     },
     "react-toastify": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.7.0",
         "react-scripts": "5.0.1",
+        "react-secure-storage": "^1.0.22",
         "react-toastify": "^9.1.1",
         "typescript": "^4.9.4",
         "web-vitals": "^2.1.4"
@@ -6191,6 +6192,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -12379,6 +12385,11 @@
         "multicast-dns": "cli.js"
       }
     },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
+    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -14763,6 +14774,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/react-secure-storage": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/react-secure-storage/-/react-secure-storage-1.0.22.tgz",
+      "integrity": "sha512-/Cc1uPynXMG1rdjRSNg6nSCDz2RYGIkFab0axUiZ4ne3ZrtGWBbRNJ9474oLI+MTFj9LupN9832j0rV9kr8D+A==",
+      "dependencies": {
+        "crypto-js": "^4.1.1",
+        "murmurhash-js": "^1.0.0"
+      }
     },
     "node_modules/react-toastify": {
       "version": "9.1.1",
@@ -21901,6 +21921,11 @@
         "which": "^2.0.1"
       }
     },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -26375,6 +26400,11 @@
         "thunky": "^1.0.2"
       }
     },
+    "murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
+    },
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -27912,6 +27942,15 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
+      }
+    },
+    "react-secure-storage": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/react-secure-storage/-/react-secure-storage-1.0.22.tgz",
+      "integrity": "sha512-/Cc1uPynXMG1rdjRSNg6nSCDz2RYGIkFab0axUiZ4ne3ZrtGWBbRNJ9474oLI+MTFj9LupN9832j0rV9kr8D+A==",
+      "requires": {
+        "crypto-js": "^4.1.1",
+        "murmurhash-js": "^1.0.0"
       }
     },
     "react-toastify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^6.7.0",
     "react-scripts": "5.0.1",
     "react-secure-storage": "^1.0.22",
+    "react-spotify-web-playback-sdk": "^3.0.1",
     "react-toastify": "^9.1.1",
     "typescript": "^4.9.4",
     "web-vitals": "^2.1.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.7.0",
     "react-scripts": "5.0.1",
+    "react-secure-storage": "^1.0.22",
     "react-toastify": "^9.1.1",
     "typescript": "^4.9.4",
     "web-vitals": "^2.1.4"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,6 @@ function App() {
                                 <Route path="/" element={<Navigate to="/mixtapes"/>}/>
                                 <Route path="/mixtapes" element={<MixtapesOverviewPage/>}/>
                                 <Route path="/mixtapes/:id" element={<MixtapeDetailPage/>}/>
-                                <Route path="/play" element={<PlayMixtapePage/>}/>
                                 <Route path="/play/:id" element={<PlayMixtapePage/>}/>
                             </Route>
                         </Route>

--- a/frontend/src/api/mixify-api.ts
+++ b/frontend/src/api/mixify-api.ts
@@ -1,4 +1,4 @@
-import User from "../types/user";
+import {AuthenticatedUser} from "../types/user";
 import axios from "axios";
 import Mixtape from "../types/mixtape";
 import Form from "../types/forms";
@@ -10,7 +10,7 @@ export namespace UserApi {
         baseURL: "/api/users"
     });
 
-    export async function getAuthenticatedUser(): Promise<User> {
+    export async function getAuthenticatedUser(): Promise<AuthenticatedUser> {
         const response = await client.get("/me");
 
         return response.data;

--- a/frontend/src/api/spotify-api.ts
+++ b/frontend/src/api/spotify-api.ts
@@ -25,7 +25,7 @@ class SpotifyApi {
         return response.data.tracks.items ?? [];
     }
 
-    async queueTracks(uris: string[], deviceId: string) {
+    async addTracks(uris: string[], deviceId: string) {
         return await this.client.put(
             `/me/player/play?device_id=${deviceId}`,
             {

--- a/frontend/src/api/spotify-api.ts
+++ b/frontend/src/api/spotify-api.ts
@@ -24,6 +24,16 @@ class SpotifyApi {
 
         return response.data.tracks.items ?? [];
     }
+
+    async queueTracks(uris: string[], deviceId: string) {
+        return await this.client.put(
+            `/me/player/play?device_id=${deviceId}`,
+            {
+                uris: uris,
+                position_ms: 0,
+            },
+        );
+    }
 }
 
 export default SpotifyApi;

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -2,15 +2,23 @@ import {BottomNavigation, BottomNavigationAction, Paper} from "@mui/material";
 import {PlayCircle as PlayCircleIcon, QueueMusic as QueueMusicIcon} from "@mui/icons-material";
 import React, {useEffect, useState} from "react";
 import {useLocation, useNavigate} from "react-router-dom";
+import localStorage from  "react-secure-storage";
+import StorageKey from "../utils/local-storage-utils";
 
 export default function BottomNav() {
     const navigate = useNavigate();
     const location = useLocation();
 
     const [value, setValue] = useState<string>(location.pathname);
+    const [lastPlayUrl, setLastPlayUrl] = useState<string|null>();
 
     useEffect(() => {
         setValue(location.pathname);
+
+        const lastPlayUrl = localStorage.getItem(StorageKey.LAST_PLAY_URL);
+        if (lastPlayUrl) {
+            setLastPlayUrl(String(lastPlayUrl));
+        }
     }, [location])
 
     return (
@@ -18,12 +26,14 @@ export default function BottomNav() {
             <BottomNavigation
                 value={value}
             >
-                <BottomNavigationAction
+                {lastPlayUrl &&
+                  <BottomNavigationAction
                     label="Player"
                     icon={<PlayCircleIcon fontSize="large"/>}
-                    value="/play"
-                    onClick={() => navigate("/play")}
-                />
+                    value={lastPlayUrl}
+                    onClick={() => navigate(lastPlayUrl)}
+                  />
+                }
                 <BottomNavigationAction
                     label="Mixtapes"
                     icon={<QueueMusicIcon fontSize="large"/>}

--- a/frontend/src/components/CardImage.tsx
+++ b/frontend/src/components/CardImage.tsx
@@ -1,0 +1,38 @@
+import {Box, CardMedia, IconButton} from "@mui/material";
+import React from "react";
+import {PlayCircle as PlayCircleIcon} from "@mui/icons-material";
+import {Link} from "react-router-dom";
+import Image from "../types/image";
+
+export default function CardImage({image, link}: {
+    image: Image,
+    link: string,
+}) {
+    return (
+        <Box sx={{position: "relative"}}>
+            <CardMedia
+                component="img"
+                image={image.src}
+                alt={image.alt}
+                sx={{
+                    width: image.size,
+                    height: image.size,
+                    lineHeight: 0,
+                    border: "1px solid grey"
+                }}
+            />
+            <IconButton size="large" component={Link} to={link} aria-label="play" sx={{
+                display: "block",
+                m: 0,
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                height: "100%",
+                zIndex: 1
+            }}>
+                <PlayCircleIcon sx={{width: "70%", height: "100%"}}/>
+            </IconButton>
+        </Box>
+    )
+}

--- a/frontend/src/components/MainLayout.tsx
+++ b/frontend/src/components/MainLayout.tsx
@@ -2,15 +2,36 @@ import HeaderNav from "./HeaderNav";
 import BottomNav from "./BottomNav";
 import {Outlet} from "react-router-dom";
 import {Container} from "@mui/material";
+import {WebPlaybackSDK} from "react-spotify-web-playback-sdk";
+import {useUserContext} from "../context/userContext";
+import {useCallback} from "react";
 
 export default function MainLayout() {
+    const {user} = useUserContext();
+
+    const getAccessToken = useCallback((callback: (token: string) => void) => {
+        if (!user) {
+            return;
+        }
+
+        callback(user.providerAccessToken);
+    }, [user]);
+
     return (
         <>
             <HeaderNav/>
 
-            <Container maxWidth="md" sx={{p: 2, mb: 10}}>
-                <Outlet/>
-            </Container>
+            {/* @ts-ignore */}
+            <WebPlaybackSDK
+                initialDeviceName="Mixify"
+                getOAuthToken={getAccessToken}
+                initialVolume={0.5}
+                connectOnInitialized={false}
+            >
+                <Container maxWidth="md" sx={{p: 2, mb: 10}}>
+                    <Outlet/>
+                </Container>
+            </WebPlaybackSDK>
 
             <BottomNav/>
         </>

--- a/frontend/src/components/MainLayout.tsx
+++ b/frontend/src/components/MainLayout.tsx
@@ -19,21 +19,23 @@ export default function MainLayout() {
 
     return (
         <>
-            <HeaderNav/>
+            {user &&
+                /* @ts-ignore */
+                <WebPlaybackSDK
+                  initialDeviceName="Mixify"
+                  getOAuthToken={getAccessToken}
+                  initialVolume={0.5}
+                  connectOnInitialized={true}
+                >
+                  <HeaderNav/>
 
-            {/* @ts-ignore */}
-            <WebPlaybackSDK
-                initialDeviceName="Mixify"
-                getOAuthToken={getAccessToken}
-                initialVolume={0.5}
-                connectOnInitialized={false}
-            >
-                <Container maxWidth="md" sx={{p: 2, mb: 10}}>
+                  <Container maxWidth="md" sx={{p: 2, mb: 10}}>
                     <Outlet/>
-                </Container>
-            </WebPlaybackSDK>
+                  </Container>
 
-            <BottomNav/>
+                  <BottomNav/>
+                </WebPlaybackSDK>
+            }
         </>
     );
 }

--- a/frontend/src/components/MixtapeCard.tsx
+++ b/frontend/src/components/MixtapeCard.tsx
@@ -1,7 +1,7 @@
 import Mixtape from "../types/mixtape";
 import {
     Backdrop,
-    Card, CardActionArea, CardActions, CardContent, CardMedia,
+    Card, CardActionArea, CardActions, CardContent,
     Container,
     IconButton,
     ListItemIcon,
@@ -20,6 +20,7 @@ import {toast} from "react-toastify";
 import useForm from "../hooks/useForm";
 import useMenu from "../hooks/useMenu";
 import {Link} from "react-router-dom";
+import CardImage from "./CardImage";
 
 export default function MixtapeCard({mixtape, onEdit, onDelete}: {
     mixtape: Mixtape,
@@ -48,14 +49,17 @@ export default function MixtapeCard({mixtape, onEdit, onDelete}: {
 
     return (
         <Card elevation={5} sx={{display: "flex", position: "relative"}}>
-            <CardActionArea component={Link} to={`/mixtapes/${mixtape.id}`} sx={{display: "flex", justifyContent: "flex-start", alignItems: "stretch", p: 2}}>
-                <CardMedia
-                    component="img"
-                    image={mixtape.imageUrl}
-                    alt={mixtape.title}
-                    sx={{width: 100, height: 100, lineHeight: 0, border: "1px solid grey"}}
-                />
+            <CardActions sx={{p: 2, pr: 0}}>
+                <CardImage image={{src: mixtape.imageUrl, alt: mixtape.title, size: 100}} link={`/play/${mixtape.id}`}/>
+            </CardActions>
 
+            <CardActionArea component={Link} to={`/mixtapes/${mixtape.id}`} sx={{
+                display: "flex",
+                justifyContent: "flex-start",
+                alignItems: "stretch",
+                p: 0,
+                paddingBlock: 2
+            }}>
                 <CardContent sx={{display: "flex", alignItems: "stretch"}}>
                     <Container
                         sx={{display: "flex", flexDirection: "column", justifyContent: "space-between", p: 0}}>

--- a/frontend/src/components/MixtapeDetails.tsx
+++ b/frontend/src/components/MixtapeDetails.tsx
@@ -3,7 +3,7 @@ import ConfirmDialog from "./ConfirmDialog";
 import MixtapeForm from "./MixtapeForm";
 import {
     Backdrop, Box,
-    CardMedia, Container,
+    Container,
     IconButton, ListItemIcon, Menu, MenuItem,
     Typography
 } from "@mui/material";
@@ -15,6 +15,7 @@ import {MixtapeApi} from "../api/mixify-api";
 import {toast} from "react-toastify";
 import MixtapeUtils from "../utils/mixtape-utils";
 import {Close as CloseIcon, Edit as EditIcon, MoreVert as MoreVertIcon} from "@mui/icons-material";
+import CardImage from "./CardImage";
 
 export default function MixtapeDetails({mixtape, onEdit, onDelete}: {
     mixtape: Mixtape,
@@ -45,12 +46,7 @@ export default function MixtapeDetails({mixtape, onEdit, onDelete}: {
         <Container sx={{display: "flex", flexDirection: "column", gap: 2, p: 0}}>
             <Container sx={{display: "flex", width: "100%", p: 0, position: "relative"}}>
                 <Box sx={{flex: 1}}>
-                    <CardMedia
-                        component="img"
-                        image={mixtape.imageUrl}
-                        alt={mixtape.title}
-                        sx={{width: 130, height: 130, lineHeight: 0, border: "1px solid grey", flex: 1}}
-                    />
+                    <CardImage image={{src: mixtape.imageUrl, alt: mixtape.title, size: 130}} link={`/play/${mixtape.id}`}/>
                 </Box>
 
                 <Container sx={{display: "flex", flexDirection: "column", justifyContent: "center"}}>

--- a/frontend/src/context/userContext.tsx
+++ b/frontend/src/context/userContext.tsx
@@ -1,7 +1,7 @@
-import User from "../types/user";
+import {AuthenticatedUser} from "../types/user";
 import {createContext, Dispatch, ReactNode, SetStateAction, useContext, useState} from "react";
 
-const UserContext = createContext<{user: User|null, setUser: Dispatch<SetStateAction<User|null>>}>({
+const UserContext = createContext<{user: AuthenticatedUser|null, setUser: Dispatch<SetStateAction<AuthenticatedUser|null>>}>({
     user: null,
     setUser: () => undefined
 });
@@ -9,7 +9,7 @@ const UserContext = createContext<{user: User|null, setUser: Dispatch<SetStateAc
 export function UserProvider({children}: {
     children: ReactNode|ReactNode[]
 }) {
-    const [user, setUser] = useState<User|null>(null);
+    const [user, setUser] = useState<AuthenticatedUser|null>(null);
 
     return (
         <UserContext.Provider value={{user, setUser}}>

--- a/frontend/src/hooks/useMixtapePlayer.ts
+++ b/frontend/src/hooks/useMixtapePlayer.ts
@@ -1,0 +1,32 @@
+import {usePlayerDevice, useSpotifyPlayer, useWebPlaybackSDKReady} from "react-spotify-web-playback-sdk";
+import useSpotifyApi from "./useSpotifyApi";
+import {useCallback, useEffect, useState} from "react";
+
+export default function useMixtapePlayer() {
+    const [playerReady, setPlayerReady] = useState<boolean>(false);
+
+    const webPlaybackSDKReady = useWebPlaybackSDKReady();
+    const player = useSpotifyPlayer();
+    const device = usePlayerDevice();
+    const spotifyApi = useSpotifyApi();
+
+    const addTracksToPlayer = useCallback(async (uris: string[]) => {
+        await spotifyApi?.addTracks(uris, device?.device_id ?? "");
+    }, [spotifyApi, device]);
+
+    useEffect(() => {
+        if (webPlaybackSDKReady && spotifyApi && device && device.status === "ready") {
+            setPlayerReady(true);
+        }
+    }, [webPlaybackSDKReady, spotifyApi, device, setPlayerReady]);
+
+    const startPlayer = useCallback(async () => {
+        return player?.resume();
+    }, [player]);
+
+    const pausePlayer = useCallback(async () => {
+        return player?.pause();
+    }, [player]);
+
+    return {playerReady, addTracksToPlayer, startPlayer, pausePlayer};
+}

--- a/frontend/src/hooks/useSpotifyApi.ts
+++ b/frontend/src/hooks/useSpotifyApi.ts
@@ -1,8 +1,12 @@
 import SpotifyApi from "../api/spotify-api";
 import {useUserContext} from "../context/userContext";
 
-export default function useSpotifyApi(): SpotifyApi {
+export default function useSpotifyApi(): SpotifyApi|null {
     const {user} = useUserContext();
 
-    return new SpotifyApi(user?.providerAccessToken ?? "");
+    if (!user) {
+        return null;
+    }
+
+    return new SpotifyApi(user?.providerAccessToken);
 }

--- a/frontend/src/hooks/useSpotifyTrackSearch.ts
+++ b/frontend/src/hooks/useSpotifyTrackSearch.ts
@@ -9,6 +9,10 @@ export default function useSpotifyTrackSearch() {
     const [selectedSearchResult, setSelectedSearchResult] = useState<Spotify.Track | null>(null);
 
     const searchTracks = async (q: string) => {
+        if (!spotifyApi) {
+            return;
+        }
+
         const results: Spotify.Track[] = await spotifyApi.searchTracks(q);
         setSearchResults(results);
     }

--- a/frontend/src/pages/PlayMixtapePage.tsx
+++ b/frontend/src/pages/PlayMixtapePage.tsx
@@ -1,23 +1,44 @@
-import {useLocation, useParams} from "react-router-dom";
+import {Location, useLocation, useParams} from "react-router-dom";
 import useMixtape from "../hooks/useMixtape";
 import localStorage from  "react-secure-storage";
 import {useEffect} from "react";
 import StorageKey from "../utils/local-storage-utils";
+import {usePlayerDevice, useSpotifyPlayer, useWebPlaybackSDKReady} from "react-spotify-web-playback-sdk";
+import useSpotifyApi from "../hooks/useSpotifyApi";
 
 export default function PlayMixtapePage() {
     const location = useLocation();
     const {id} = useParams<{ id: string }>();
     const {mixtape} = useMixtape(id);
 
+    const ready = useWebPlaybackSDKReady();
+    const player = useSpotifyPlayer();
+    const device = usePlayerDevice();
+
+    const spotifyApi = useSpotifyApi();
+
     useEffect(() => {
-        if (!id) {
+        if (!player) {
             return;
         }
 
-        localStorage.setItem(StorageKey.LAST_PLAY_URL, location.pathname);
-    }, [location, id]);
+        return ensurePlayerIsPausedIfUserLeavesPage(player);
+    }, [player]);
 
-    // put all tracks to spotify queue
+    useEffect(() => {
+        updateLastPlayUrlInLocalStorage(location);
+    }, [location]);
+
+    useEffect(() => {
+        if (!spotifyApi || !mixtape || !device || device.status !== "ready") {
+            return;
+        }
+
+        (async() => {
+            const uris = mixtape.tracks.map(track => track.providerUri);
+            await spotifyApi?.queueTracks(uris, device.device_id);
+        })();
+    }, [ready, spotifyApi, device, mixtape]);
 
     return (
         <>
@@ -27,4 +48,12 @@ export default function PlayMixtapePage() {
             }
         </>
     );
+}
+
+function ensurePlayerIsPausedIfUserLeavesPage(player: Spotify.Player): () => void {
+    return () => player.pause();
+}
+
+function updateLastPlayUrlInLocalStorage(currentLocation: Location) {
+    localStorage.setItem(StorageKey.LAST_PLAY_URL, currentLocation.pathname);
 }

--- a/frontend/src/pages/PlayMixtapePage.tsx
+++ b/frontend/src/pages/PlayMixtapePage.tsx
@@ -1,7 +1,30 @@
+import {useLocation, useParams} from "react-router-dom";
+import useMixtape from "../hooks/useMixtape";
+import localStorage from  "react-secure-storage";
+import {useEffect} from "react";
+import StorageKey from "../utils/local-storage-utils";
+
 export default function PlayMixtapePage() {
+    const location = useLocation();
+    const {id} = useParams<{ id: string }>();
+    const {mixtape} = useMixtape(id);
+
+    useEffect(() => {
+        if (!id) {
+            return;
+        }
+
+        localStorage.setItem(StorageKey.LAST_PLAY_URL, location.pathname);
+    }, [location, id]);
+
+    // put all tracks to spotify queue
+
     return (
         <>
             <h1>Play mixtape</h1>
+            {mixtape &&
+              <p>{mixtape.title}</p>
+            }
         </>
     );
 }

--- a/frontend/src/pages/PlayerPage.tsx
+++ b/frontend/src/pages/PlayerPage.tsx
@@ -1,7 +1,0 @@
-export default function PlayerPage() {
-    return (
-        <>
-            <h1>Player</h1>
-        </>
-    )
-}

--- a/frontend/src/types/image.ts
+++ b/frontend/src/types/image.ts
@@ -1,0 +1,7 @@
+type Image = {
+    src: string,
+    alt: string,
+    size: number | string
+}
+
+export default Image;

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,9 +1,12 @@
 type User = {
-    id?: string,
+    id: string,
     name: string,
-    imageUrl: string,
-    providerAccessToken?: string,
-    providerRefreshToken?: string
+    imageUrl: string
+}
+
+export type AuthenticatedUser = User & {
+    providerAccessToken: string,
+    providerRefreshToken: string
 }
 
 export default User;

--- a/frontend/src/utils/local-storage-utils.ts
+++ b/frontend/src/utils/local-storage-utils.ts
@@ -1,0 +1,5 @@
+enum StorageKey {
+    LAST_PLAY_URL = "lastPlayUrl"
+}
+
+export default StorageKey;


### PR DESCRIPTION
- added PlayButton to images on MixtapeCard and MixtapeDetails that links to the PlayMixtapePage
- store information which mixtape is played last in local storage
- the bottomNav PlayButton links to the last played mixtape
- added Spotify WebPlaybackSDK stuff to create an independent device for playing Spotify songs
- added missing scopes for spotify API, that are needed to control player
- distinguish between AuthenticatedUser and User e.g. as creator of a mixtape by using different types
