### PR TITLE
More tweaks

### DIFF
--- a/frontend/src/api/spotify-api.ts
+++ b/frontend/src/api/spotify-api.ts
@@ -26,7 +26,7 @@ class SpotifyApi {
         return response.data.tracks.items ?? [];
     }
 
-    async addTracks(uris: string[], deviceId: string) {
+    async addTracks(uris: string[], startUri: string, deviceId: string) {
         if (this.alreadyAddedTracks) {
             return;
         }
@@ -35,6 +35,9 @@ class SpotifyApi {
             `/me/player/play?device_id=${deviceId}`,
             {
                 uris: uris,
+                offset: {
+                    uri: startUri
+                }
             },
         );
 

--- a/frontend/src/components/CardImageWithPlayButton.tsx
+++ b/frontend/src/components/CardImageWithPlayButton.tsx
@@ -1,12 +1,12 @@
 import {Box, CardMedia, IconButton} from "@mui/material";
 import React from "react";
 import {PlayCircle as PlayCircleIcon} from "@mui/icons-material";
-import {Link} from "react-router-dom";
 import Image from "../types/image";
 
-export default function CardImage({image, link}: {
+export default function CardImageWithPlayButton({image, opacity = 1, onClick}: {
     image: Image,
-    link: string,
+    opacity?: number,
+    onClick?: () => void,
 }) {
     return (
         <Box sx={{position: "relative"}}>
@@ -18,21 +18,24 @@ export default function CardImage({image, link}: {
                     width: image.size,
                     height: image.size,
                     lineHeight: 0,
-                    border: "1px solid grey"
+                    border: "1px solid grey",
+                    opacity: opacity,
                 }}
             />
-            <IconButton size="large" component={Link} to={link} aria-label="play" sx={{
-                display: "block",
-                m: 0,
-                position: "absolute",
-                top: 0,
-                left: 0,
-                width: "100%",
-                height: "100%",
-                zIndex: 1
-            }}>
+            {onClick &&
+              <IconButton size="large" onClick={() => onClick()} aria-label="play" sx={{
+                  display: "block",
+                  m: 0,
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: "100%",
+                  zIndex: 1
+              }}>
                 <PlayCircleIcon sx={{width: "70%", height: "100%"}}/>
-            </IconButton>
+              </IconButton>
+            }
         </Box>
     )
 }

--- a/frontend/src/components/FlippableImageCard.tsx
+++ b/frontend/src/components/FlippableImageCard.tsx
@@ -1,5 +1,4 @@
-import {Box, Card, CardMedia, Container, IconButton, Typography} from "@mui/material";
-import {Redo as RedoIcon} from "@mui/icons-material";
+import {Box, Card, CardActionArea, CardMedia, Typography} from "@mui/material";
 import ReactCardFlip from "react-card-flip";
 import React, {ReactNode, useState} from "react";
 import Image from "../types/image";
@@ -12,9 +11,13 @@ export default function FlippableImageCard({image, textOnBack, children}: {
     const [isImageFlipped, setIsImageFlipped] = useState<boolean>(false);
 
     return (
-        <ReactCardFlip isFlipped={isImageFlipped} flipSpeedBackToFront={1} flipSpeedFrontToBack={1} containerStyle={{width: "100%"}}>
-            <Card elevation={10} sx={{display: "flex", flexDirection: "column", width: "100%", p: 2, pb: 0}}>
-                <Container sx={{paddingTop: "100%", position: "relative"}}>
+        <ReactCardFlip isFlipped={isImageFlipped} flipSpeedBackToFront={1} flipSpeedFrontToBack={1}
+                       containerStyle={{width: "100%"}}>
+            <Card elevation={10} sx={{display: "flex", flexDirection: "column", width: "100%", p: 2}}>
+                <CardActionArea
+                    sx={{paddingTop: "100%", position: "relative"}}
+                    onClick={() => setIsImageFlipped(true)}
+                >
                     <CardMedia
                         component="img"
                         image={image.src}
@@ -30,15 +33,14 @@ export default function FlippableImageCard({image, textOnBack, children}: {
                         }}
                     />
                     {children}
-                </Container>
-
-                <IconButton onClick={() => setIsImageFlipped(!isImageFlipped)} sx={{marginLeft: "auto"}}>
-                    <RedoIcon/>
-                </IconButton>
+                </CardActionArea>
             </Card>
 
-            <Card elevation={10} square={true} sx={{display: "flex", flexDirection: "column", width: "100%", p: 2, pb: 0}}>
-                <Container sx={{paddingTop: "100%", position: "relative"}}>
+            <Card elevation={10} square={true} sx={{display: "flex", flexDirection: "column", width: "100%", p: 2}}>
+                <CardActionArea
+                    sx={{paddingTop: "100%", position: "relative"}}
+                    onClick={() => setIsImageFlipped(false)}
+                >
                     <CardMedia
                         component="img"
                         image={image.src}
@@ -67,11 +69,7 @@ export default function FlippableImageCard({image, textOnBack, children}: {
                     }}>
                         <Typography variant="h2" textAlign="justify">{textOnBack}</Typography>
                     </Box>
-                </Container>
-
-                <IconButton onClick={() => setIsImageFlipped(!isImageFlipped)} sx={{marginLeft: "auto"}}>
-                    <RedoIcon/>
-                </IconButton>
+                </CardActionArea>
             </Card>
         </ReactCardFlip>
     )

--- a/frontend/src/components/FlippableTrackCard.tsx
+++ b/frontend/src/components/FlippableTrackCard.tsx
@@ -3,7 +3,7 @@ import {
     CardActionArea,
     CardActions,
     CardContent,
-    CardMedia,
+    CardMedia, Container,
     Typography
 } from "@mui/material";
 import React, {useState} from "react";
@@ -11,10 +11,12 @@ import Track from "../types/track";
 import ReactCardFlip from "react-card-flip";
 import Mixtape from "../types/mixtape";
 import TrackCardMenu from "./TrackCardMenu";
+import CardImageWithPlayButton from "./CardImageWithPlayButton";
 
-export default function FlippableTrackCard({track, mixtape, onEdit, onDelete}: {
+export default function FlippableTrackCard({track, mixtape, onImageClick, onEdit, onDelete}: {
     track: Track,
     mixtape: Mixtape,
+    onImageClick?: () => void,
     onEdit?: (savedTrack: Track) => void,
     onDelete?: (deletedTrack: Track) => void,
 }) {
@@ -23,19 +25,21 @@ export default function FlippableTrackCard({track, mixtape, onEdit, onDelete}: {
     return (
         <ReactCardFlip isFlipped={isFlipped} flipSpeedBackToFront={1} flipSpeedFrontToBack={1} containerStyle={{width: "100%"}}>
             <Card elevation={5} sx={{display: "flex", position: "relative", p: 0}}>
-                <CardActionArea sx={{display: "flex", justifyContent: "flex-start", alignItems: "stretch", p: 2}} onClick={() => setIsFlipped(true)}>
-                    <CardMedia
-                        component="img"
-                        image={track.imageUrl}
-                        alt={track.name}
-                        sx={{width: 100, height: 100, lineHeight: 0, border: "1px solid grey"}}
-                    />
-
-                    <CardContent sx={{display: "flex", flexDirection: "column", justifyContent: "center"}}>
-                        <Typography variant="h3">{track.name}</Typography>
-                        <Typography>{track.artist}</Typography>
-                    </CardContent>
-                </CardActionArea>
+                <Container sx={{display: "flex", justifyContent: "flex-start", alignItems: "stretch", p: 2}}>
+                    <CardActions sx={{p: 0}}>
+                        <CardImageWithPlayButton
+                            image={{src: track.imageUrl, alt: track.name, size: 100}}
+                            opacity={0.8}
+                            onClick={onImageClick}
+                        />
+                    </CardActions>
+                    <CardActionArea sx={{p: 0}} onClick={() => setIsFlipped(true)}>
+                        <CardContent sx={{display: "flex", flexDirection: "column", justifyContent: "center"}}>
+                            <Typography variant="h3">{track.name}</Typography>
+                            <Typography>{track.artist}</Typography>
+                        </CardContent>
+                    </CardActionArea>
+                </Container>
 
                 {onEdit && onDelete &&
                   <CardActions>
@@ -50,7 +54,7 @@ export default function FlippableTrackCard({track, mixtape, onEdit, onDelete}: {
                         component="img"
                         image={track.imageUrl}
                         alt={track.name}
-                        sx={{float: "left", mr: 2, width: 100, height: 100, lineHeight: 0, border: "1px solid grey", opacity: 0.6}}
+                        sx={{float: "left", mr: 2, width: 100, height: 100, lineHeight: 0, border: "1px solid grey", opacity: 0.4}}
                     />
 
                     <CardContent sx={{p: 0}}>

--- a/frontend/src/components/MiniPlayer.tsx
+++ b/frontend/src/components/MiniPlayer.tsx
@@ -1,13 +1,11 @@
-import {Box, Card, CardActionArea, CardActions, CardContent, CardMedia, IconButton, Typography} from "@mui/material";
-import {Pause as PauseIcon, SkipPrevious as SkipPreviousIcon} from "@mui/icons-material";
+import {Box, Card, CardActionArea, CardActions, CardContent, CardMedia, Typography} from "@mui/material";
 import PlayerProgressBar from "./PlayerProgressBar";
 import React from "react";
 import Track from "../types/track";
+import PlayerControls from "./PlayerControls";
 
-export default function MiniPlayer({track, onPause, onPrevious, onClick}: {
+export default function MiniPlayer({track, onClick}: {
     track: Track,
-    onPause: () => void,
-    onPrevious: () => void,
     onClick: () => void,
 }) {
     return (
@@ -51,12 +49,7 @@ export default function MiniPlayer({track, onPause, onPrevious, onClick}: {
                 </CardActionArea>
 
                 <CardActions>
-                    <IconButton color="primary" sx={{fontSize: 40, p: 0}} onClick={onPrevious}>
-                        <SkipPreviousIcon fontSize="inherit"/>
-                    </IconButton>
-                    <IconButton color="primary" sx={{fontSize: 40, p: 0}} onClick={onPause}>
-                        <PauseIcon fontSize="inherit"/>
-                    </IconButton>
+                    <PlayerControls size={40}/>
                 </CardActions>
             </Box>
             <PlayerProgressBar showDuration={false}/>

--- a/frontend/src/components/MixtapeCard.tsx
+++ b/frontend/src/components/MixtapeCard.tsx
@@ -18,8 +18,8 @@ import {MixtapeApi} from "../api/mixify-api";
 import {toast} from "react-toastify";
 import useForm from "../hooks/useForm";
 import useMenu from "../hooks/useMenu";
-import {Link} from "react-router-dom";
-import CardImage from "./CardImage";
+import {Link, useNavigate} from "react-router-dom";
+import CardImageWithPlayButton from "./CardImageWithPlayButton";
 import {useBackdrop} from "../context/backdropContext";
 
 export default function MixtapeCard({mixtape, onEdit, onDelete}: {
@@ -27,6 +27,7 @@ export default function MixtapeCard({mixtape, onEdit, onDelete}: {
     onEdit: (savedMixtape: Mixtape) => void,
     onDelete: (deletedMixtape: Mixtape) => void,
 }) {
+    const navigate = useNavigate();
     const {menuAnchorEl: mixtapeAnchorEl, isMenuOpen: isMixtapeMenuOpen, openMenu: openMixtapeMenu, closeMenu: closeMixtapeMenu} = useMenu();
     const {isFormOpen: isMixtapeFormOpen, openForm: openMixtapeForm, closeForm: closeMixtapeForm} = useForm();
     const {enableBackdrop} = useBackdrop();
@@ -55,7 +56,10 @@ export default function MixtapeCard({mixtape, onEdit, onDelete}: {
     return (
         <Card elevation={5} sx={{display: "flex", position: "relative"}}>
             <CardActions sx={{p: 2, pr: 0}}>
-                <CardImage image={{src: mixtape.imageUrl, alt: mixtape.title, size: 100}} link={`/play/${mixtape.id}`}/>
+                <CardImageWithPlayButton
+                    image={{src: mixtape.imageUrl, alt: mixtape.title, size: 100}}
+                    onClick={() => navigate(`/play/${mixtape.id}`)}
+                />
             </CardActions>
 
             <CardActionArea component={Link} to={`/mixtapes/${mixtape.id}`} sx={{

--- a/frontend/src/components/MixtapeDetails.tsx
+++ b/frontend/src/components/MixtapeDetails.tsx
@@ -15,14 +15,16 @@ import {MixtapeApi} from "../api/mixify-api";
 import {toast} from "react-toastify";
 import MixtapeUtils from "../utils/mixtape-utils";
 import {Close as CloseIcon, Edit as EditIcon, MoreVert as MoreVertIcon} from "@mui/icons-material";
-import CardImage from "./CardImage";
+import CardImageWithPlayButton from "./CardImageWithPlayButton";
 import {useBackdrop} from "../context/backdropContext";
+import {useNavigate} from "react-router-dom";
 
 export default function MixtapeDetails({mixtape, onEdit, onDelete}: {
     mixtape: Mixtape,
     onEdit: (savedMixtape: Mixtape) => void,
     onDelete: (deletedMixtape: Mixtape) => void,
 }) {
+    const navigate = useNavigate();
     const {menuAnchorEl: mixtapeMenuAnchorEl, isMenuOpen: isMixtapeMenuOpen, openMenu: openMixtapeMenu, closeMenu: closeMixtapeMenu} = useMenu();
     const {isFormOpen: isMixtapeFormOpen, openForm: openMixtapeForm, closeForm: closeMixtapeForm} = useForm();
     const {enableBackdrop} = useBackdrop();
@@ -52,7 +54,10 @@ export default function MixtapeDetails({mixtape, onEdit, onDelete}: {
         <Container sx={{display: "flex", flexDirection: "column", gap: 2, p: 0}}>
             <Container sx={{display: "flex", width: "100%", p: 0, position: "relative"}}>
                 <Box sx={{flex: 1}}>
-                    <CardImage image={{src: mixtape.imageUrl, alt: mixtape.title, size: 130}} link={`/play/${mixtape.id}`}/>
+                    <CardImageWithPlayButton
+                        image={{src: mixtape.imageUrl, alt: mixtape.title, size: 130}}
+                        onClick={() => navigate(`/play/${mixtape.id}`)}
+                    />
                 </Box>
 
                 <Container sx={{display: "flex", flexDirection: "column", justifyContent: "center"}}>

--- a/frontend/src/components/PlayedTracksList.tsx
+++ b/frontend/src/components/PlayedTracksList.tsx
@@ -1,0 +1,43 @@
+import {Container, List, ListItem, Typography} from "@mui/material";
+import FlippableTrackCard from "./FlippableTrackCard";
+import {Info as InfoIcon} from "@mui/icons-material";
+import React from "react";
+import Mixtape from "../types/mixtape";
+import Track from "../types/track";
+
+export default function PlayedTracksList({mixtape, playedTracks, onTrackPlay}: {
+    mixtape: Mixtape,
+    playedTracks: Track[],
+    onTrackPlay: (trackIndex: number) => void,
+}) {
+    return (
+        <>
+            <List sx={{display: "flex", flexDirection: "column", gap: 2, p: 0, width: "100%"}}>
+                {playedTracks.map((track, index) => (
+                    <ListItem key={track.id} sx={{p: 0}}>
+                        <Container
+                            sx={{display: "flex", justifyContent: "space-between", alignItems: "center", p: 0}}
+                        >
+                            <Typography variant="h1" component="h3" sx={{mr: 2}}>{index + 1}</Typography>
+                            <FlippableTrackCard
+                                track={track}
+                                mixtape={mixtape}
+                                onImageClick={() => onTrackPlay(index)}
+                            />
+                        </Container>
+                    </ListItem>
+                ))}
+            </List>
+
+            {playedTracks.length !== mixtape.tracks.length &&
+              <Typography sx={{display: "flex", alignItems: "center"}}>
+                <InfoIcon color="primary" sx={{mr: 1}}/>
+                  {playedTracks.length === 0
+                      ? "Start listening to this mixtape to reveal the tracks."
+                      : "Continue listening to reveal the remaining tracks."
+                  }
+              </Typography>
+            }
+        </>
+    )
+}

--- a/frontend/src/components/PlayerControls.tsx
+++ b/frontend/src/components/PlayerControls.tsx
@@ -1,0 +1,27 @@
+import {IconButton} from "@mui/material";
+import {Pause as PauseIcon, PlayArrow as PlayArrowIcon, SkipPrevious as SkipPreviousIcon} from "@mui/icons-material";
+import React from "react";
+import {usePlaybackState, useSpotifyPlayer} from "react-spotify-web-playback-sdk";
+
+export default function PlayerControls({size}: {
+    size: number | string
+}) {
+    const player = useSpotifyPlayer();
+    const state = usePlaybackState();
+
+    return (
+        <>
+            <IconButton color="primary" sx={{fontSize: size, p: 0}} onClick={() => player?.previousTrack()}>
+                <SkipPreviousIcon fontSize="inherit"/>
+            </IconButton>
+            {state && state.paused
+                ? <IconButton color="primary" sx={{fontSize: size, p: 0}} onClick={() => player?.resume()}>
+                    <PlayArrowIcon fontSize="inherit"/>
+                </IconButton>
+                : <IconButton color="primary" sx={{fontSize: size, p: 0}} onClick={() => player?.pause()}>
+                    <PauseIcon fontSize="inherit"/>
+                </IconButton>
+            }
+        </>
+    )
+}

--- a/frontend/src/components/PlayerControls.tsx
+++ b/frontend/src/components/PlayerControls.tsx
@@ -7,11 +7,21 @@ export default function PlayerControls({size}: {
     size: number | string
 }) {
     const player = useSpotifyPlayer();
-    const state = usePlaybackState();
+    const state = usePlaybackState(true);
+
+    const onPrevious = () => {
+        if (!state) return;
+
+        if (state?.position < 5000) {
+            player?.previousTrack();
+        } else {
+            player?.seek(0);
+        }
+    }
 
     return (
         <>
-            <IconButton color="primary" sx={{fontSize: size, p: 0}} onClick={() => player?.previousTrack()}>
+            <IconButton color="primary" sx={{fontSize: size, p: 0}} onClick={onPrevious}>
                 <SkipPreviousIcon fontSize="inherit"/>
             </IconButton>
             {state && state.paused

--- a/frontend/src/components/PlayerTrackView.tsx
+++ b/frontend/src/components/PlayerTrackView.tsx
@@ -1,19 +1,17 @@
-import {Box, Container, IconButton, Modal, Typography} from "@mui/material";
-import {Pause as PauseIcon, SkipPrevious as SkipPreviousIcon} from "@mui/icons-material";
+import {Box, Container, Modal, Typography} from "@mui/material";
 import FlippableImageCard from "./FlippableImageCard";
 import React from "react";
 import Track from "../types/track";
 import ModalHeader from "./ModalHeader";
 import PlayerProgressBar from "./PlayerProgressBar";
 import Mixtape from "../types/mixtape";
+import PlayerControls from "./PlayerControls";
 
-export default function PlayerTrackView({open, mixtape, track, ready, onPause, onPrevious, onClose}: {
+export default function PlayerTrackView({open, mixtape, track, ready, onClose}: {
     open: boolean,
     mixtape: Mixtape,
     track: Track,
     ready: boolean,
-    onPause: () => void,
-    onPrevious: () => void,
     onClose: () => void,
 }) {
     return (
@@ -50,12 +48,7 @@ export default function PlayerTrackView({open, mixtape, track, ready, onPause, o
 
                     {ready &&
                       <Box sx={{display: "flex", justifyContent: "center"}}>
-                        <IconButton color="primary" sx={{fontSize: 80, p: 0}} onClick={onPrevious}>
-                          <SkipPreviousIcon fontSize="inherit"/>
-                        </IconButton>
-                        <IconButton color="primary" sx={{fontSize: 80, p: 0}} onClick={onPause}>
-                          <PauseIcon fontSize="inherit"/>
-                        </IconButton>
+                        <PlayerControls size={80}/>
                       </Box>
                     }
                 </Box>

--- a/frontend/src/pages/PlayMixtapePage.tsx
+++ b/frontend/src/pages/PlayMixtapePage.tsx
@@ -6,11 +6,9 @@ import StorageKey from "../utils/local-storage-utils";
 import {
     Box,
     Container,
-    List, ListItem,
     Typography
 } from "@mui/material";
 import PageHeader from "../components/PageHeader";
-import FlippableTrackCard from "../components/FlippableTrackCard";
 import {
     usePlaybackState,
     usePlayerDevice,
@@ -20,13 +18,11 @@ import useSpotifyApi from "../hooks/useSpotifyApi";
 import Track from "../types/track";
 import PlayerTrackView from "../components/PlayerTrackView";
 import useOpenClose from "../hooks/useOpenClose";
-import {
-    Info as InfoIcon,
-} from "@mui/icons-material";
 import FlippableImageCard from "../components/FlippableImageCard";
 import UserAvatar from "../components/UserAvatar";
 import MixtapeUtils from "../utils/mixtape-utils";
 import MiniPlayer from "../components/MiniPlayer";
+import PlayedTracksList from "../components/PlayedTracksList";
 
 export default function PlayMixtapePage() {
     const location = useLocation();
@@ -114,29 +110,11 @@ export default function PlayMixtapePage() {
                 </Box>
             </Box>
 
-            {mixtape && playedTracks &&
-              <List sx={{display: "flex", flexDirection: "column", gap: 2, p: 0, width: "100%"}}>
-                  {playedTracks.map((track, index) => (
-                      <ListItem key={track.id} sx={{p: 0}}>
-                          <Container
-                              sx={{display: "flex", justifyContent: "space-between", alignItems: "center", p: 0}}>
-                              <Typography variant="h1" component="h3" sx={{mr: 2}}>{index + 1}</Typography>
-                              <FlippableTrackCard track={track} mixtape={mixtape} onImageClick={() => addTracks(mixtape.tracks || [], index)}/>
-                          </Container>
-                      </ListItem>
-                  ))}
-              </List>
-            }
-
-            {playedTracks.length !== mixtape.tracks.length &&
-                <Typography sx={{display: "flex", alignItems: "center"}}>
-                  <InfoIcon color="primary" sx={{mr: 1}}/>
-                    {playedTracks.length === 0
-                        ? "Start listening to this mixtape to reveal the tracks."
-                        : "Continue listening to reveal the remaining tracks."
-                    }
-                </Typography>
-            }
+            <PlayedTracksList
+                mixtape={mixtape}
+                playedTracks={playedTracks}
+                onTrackPlay={(trackIndex: number) => addTracks(mixtape.tracks || [], trackIndex)}
+            />
 
             {currentTrack && state &&
               <MiniPlayer track={currentTrack} onClick={openTrackView}/>

--- a/frontend/src/pages/PlayMixtapePage.tsx
+++ b/frontend/src/pages/PlayMixtapePage.tsx
@@ -48,15 +48,6 @@ export default function PlayMixtapePage() {
         return player?.resume();
     };
 
-    const pausePlayer = async () => {
-        closeTrackView();
-        return player?.pause();
-    };
-
-    const playPreviousTrack = async () => {
-        return player?.previousTrack();
-    };
-
     useEffect(() => {
         updateLastPlayUrlInLocalStorage(location);
     }, [location]);
@@ -169,8 +160,8 @@ export default function PlayMixtapePage() {
                 </Typography>
             }
 
-            {currentTrack && state && !state.paused &&
-              <MiniPlayer track={currentTrack} onPrevious={playPreviousTrack} onPause={pausePlayer} onClick={openTrackView}/>
+            {currentTrack && state &&
+              <MiniPlayer track={currentTrack} onClick={openTrackView}/>
             }
 
             {currentTrack &&
@@ -180,8 +171,6 @@ export default function PlayMixtapePage() {
                 track={currentTrack}
                 ready={!!device}
                 onClose={() => closeTrackView()}
-                onPause={() => pausePlayer()}
-                onPrevious={() => playPreviousTrack()}
               />
             }
 

--- a/frontend/src/pages/PlayMixtapePage.tsx
+++ b/frontend/src/pages/PlayMixtapePage.tsx
@@ -5,7 +5,7 @@ import React, {useEffect, useState} from "react";
 import StorageKey from "../utils/local-storage-utils";
 import {
     Box,
-    Container, IconButton,
+    Container,
     List, ListItem,
     Typography
 } from "@mui/material";
@@ -22,7 +22,6 @@ import PlayerTrackView from "../components/PlayerTrackView";
 import useOpenClose from "../hooks/useOpenClose";
 import {
     Info as InfoIcon,
-    PlayCircle as PlayCircleIcon,
 } from "@mui/icons-material";
 import FlippableImageCard from "../components/FlippableImageCard";
 import UserAvatar from "../components/UserAvatar";
@@ -43,10 +42,6 @@ export default function PlayMixtapePage() {
     const device = usePlayerDevice();
     const state = usePlaybackState();
     const spotifyApi = useSpotifyApi();
-
-    const startPlayer = async () => {
-        return player?.resume();
-    };
 
     useEffect(() => {
         updateLastPlayUrlInLocalStorage(location);
@@ -88,11 +83,6 @@ export default function PlayMixtapePage() {
         }
     }, [player])
 
-    const onMixtapePlay = () => {
-        startPlayer();
-        openTrackView();
-    }
-
     if (!mixtape) {
         return null;
     }
@@ -108,24 +98,7 @@ export default function PlayMixtapePage() {
         }}>
             <PageHeader title={mixtape.title}/>
 
-            <FlippableImageCard image={{src: mixtape.imageUrl, alt: mixtape.title}}
-                                textOnBack={mixtape.description}>
-                {device && state && state.paused &&
-                  <IconButton size="large" component="button" onClick={onMixtapePlay} aria-label="play"
-                              sx={{
-                                  display: "block",
-                                  m: 4,
-                                  position: "absolute",
-                                  top: 0,
-                                  left: 0,
-                                  width: "80%",
-                                  height: "80%",
-                                  zIndex: 1,
-                              }}>
-                    <PlayCircleIcon sx={{width: "70%", height: "100%"}}/>
-                  </IconButton>
-                }
-            </FlippableImageCard>
+            <FlippableImageCard image={{src: mixtape.imageUrl, alt: mixtape.title}} textOnBack={mixtape.description}/>
 
             <Box sx={{display: "flex", gap: 1, width: "100%"}}>
                 <UserAvatar user={mixtape.createdBy} sx={{width: 60, height: 60}}/>


### PR DESCRIPTION
- moved list of played tracks to separate component
- click on "previous/rewind" will start track over, if position of track is more than 5 seconds - if under 5 seconds play previous track
- make it possible to start playlist from another track, but only if the track is already revealed
- play/pause button on both: mini player and track view player