### PR TITLE
GH-97 - endpoint to create an mixtape invite

### DIFF
--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/config/AppProperties.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/config/AppProperties.java
@@ -8,11 +8,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Getter
 public class AppProperties {
     private final OAuth2 oAuth2 = new OAuth2();
+    private final Invite invite = new Invite();
 
     @Getter
     @Setter
     public static class OAuth2 {
         private String successRedirectUri;
         private String failureRedirectUri;
+    }
+
+    @Getter
+    @Setter
+    public static class Invite {
+        private String expirationTime;
     }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/controller/InviteController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/controller/InviteController.java
@@ -1,0 +1,14 @@
+package com.github.chuettenrauch.mixifyapi.invite.controller;
+
+import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/invites")
+@RequiredArgsConstructor
+public class InviteController {
+
+    private final InviteService inviteService;
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/controller/InviteController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/controller/InviteController.java
@@ -2,11 +2,10 @@ package com.github.chuettenrauch.mixifyapi.invite.controller;
 
 import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
 import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/invites")
@@ -16,7 +15,8 @@ public class InviteController {
     private final InviteService inviteService;
 
     @PostMapping
-    public Invite create(@RequestBody Invite invite) {
+    @ResponseStatus(HttpStatus.CREATED)
+    public Invite create(@RequestBody @Valid Invite invite) {
         return this.inviteService.save(invite);
     }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/controller/InviteController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/controller/InviteController.java
@@ -1,7 +1,10 @@
 package com.github.chuettenrauch.mixifyapi.invite.controller;
 
+import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
 import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class InviteController {
 
     private final InviteService inviteService;
+
+    @PostMapping
+    public Invite create(@RequestBody Invite invite) {
+        return this.inviteService.save(invite);
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
@@ -1,0 +1,25 @@
+package com.github.chuettenrauch.mixifyapi.invite.model;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DocumentReference;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Invite {
+
+    @Id
+    private String id;
+
+    @DocumentReference
+    private Mixtape mixtape;
+
+    private LocalDateTime expiredAt;
+
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
@@ -1,5 +1,6 @@
 package com.github.chuettenrauch.mixifyapi.invite.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -20,6 +21,7 @@ public class Invite {
     @DocumentReference
     private Mixtape mixtape;
 
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime expiredAt;
 
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
@@ -1,15 +1,16 @@
 package com.github.chuettenrauch.mixifyapi.invite.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.DocumentReference;
+import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
 
+@Document
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,8 +19,8 @@ public class Invite {
     @Id
     private String id;
 
-    @DocumentReference
-    private Mixtape mixtape;
+    @NotBlank
+    private String mixtape;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime expiredAt;

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
@@ -1,6 +1,7 @@
 package com.github.chuettenrauch.mixifyapi.invite.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.chuettenrauch.mixifyapi.mixtape.validation.MixtapeExists;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -20,6 +21,7 @@ public class Invite {
     private String id;
 
     @NotBlank
+    @MixtapeExists
     private String mixtape;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/repository/InviteRepository.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/repository/InviteRepository.java
@@ -1,0 +1,9 @@
+package com.github.chuettenrauch.mixifyapi.invite.repository;
+
+import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InviteRepository extends MongoRepository<Invite, String> {
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/service/InviteService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/service/InviteService.java
@@ -1,12 +1,31 @@
 package com.github.chuettenrauch.mixifyapi.invite.service;
 
+import com.github.chuettenrauch.mixifyapi.config.AppProperties;
+import com.github.chuettenrauch.mixifyapi.exception.UnprocessableEntityException;
+import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
 import com.github.chuettenrauch.mixifyapi.invite.repository.InviteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class InviteService {
 
     private final InviteRepository inviteRepository;
+
+    private final AppProperties.Invite inviteProperties;
+
+    public Invite save(Invite invite) {
+        if (invite.getId() != null) {
+            throw new UnprocessableEntityException();
+        }
+
+        Duration expirationTime = Duration.parse(inviteProperties.getExpirationTime());
+        invite.setExpiredAt(LocalDateTime.now().plus(expirationTime));
+
+        return this.inviteRepository.save(invite);
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/service/InviteService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/service/InviteService.java
@@ -16,14 +16,14 @@ public class InviteService {
 
     private final InviteRepository inviteRepository;
 
-    private final AppProperties.Invite inviteProperties;
+    private final AppProperties appProperties;
 
     public Invite save(Invite invite) {
         if (invite.getId() != null) {
             throw new UnprocessableEntityException();
         }
 
-        Duration expirationTime = Duration.parse(inviteProperties.getExpirationTime());
+        Duration expirationTime = Duration.parse(appProperties.getInvite().getExpirationTime());
         invite.setExpiredAt(LocalDateTime.now().plus(expirationTime));
 
         return this.inviteRepository.save(invite);

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/service/InviteService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/service/InviteService.java
@@ -1,0 +1,12 @@
+package com.github.chuettenrauch.mixifyapi.invite.service;
+
+import com.github.chuettenrauch.mixifyapi.invite.repository.InviteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InviteService {
+
+    private final InviteRepository inviteRepository;
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
@@ -29,17 +29,17 @@ public class MixtapeController {
 
     @GetMapping("/{id}")
     public Mixtape get(@PathVariable String id) {
-        return this.mixtapeService.findById(id);
+        return this.mixtapeService.findByIdForAuthenticatedUser(id);
     }
 
     @PutMapping("/{id}")
     public Mixtape update(@PathVariable String id, @Valid @RequestBody Mixtape mixtape) {
-        return this.mixtapeService.updateById(id, mixtape);
+        return this.mixtapeService.updateByIdForAuthenticatedUser(id, mixtape);
     }
 
     @DeleteMapping("/{id}")
     public void delete(@PathVariable String id) {
-        this.mixtapeService.deleteById(id);
+        this.mixtapeService.deleteByIdForAuthenticatedUser(id);
     }
 
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -74,6 +74,10 @@ public class MixtapeService {
                 .orElseThrow(NotFoundException::new);
     }
 
+    public boolean existsById(String id) {
+        return this.mixtapeRepository.existsById(id);
+    }
+
     private void validateTracks(Mixtape mixtape) {
         Set<ConstraintViolation<Mixtape>> errors = validator.validateProperty(mixtape, "tracks");
         if (!errors.isEmpty()) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -40,7 +40,7 @@ public class MixtapeService {
         return this.mixtapeRepository.findAllByCreatedBy(user);
     }
 
-    public Mixtape updateById(String id, Mixtape mixtape) {
+    public Mixtape updateByIdForAuthenticatedUser(String id, Mixtape mixtape) {
         User user = this.userService.getAuthenticatedUser()
                 .orElseThrow(UnauthorizedException::new);
 
@@ -55,7 +55,7 @@ public class MixtapeService {
         return this.mixtapeRepository.save(mixtape);
     }
 
-    public void deleteById(String id) {
+    public void deleteByIdForAuthenticatedUser(String id) {
         User user = this.userService.getAuthenticatedUser()
                 .orElseThrow(UnauthorizedException::new);
 
@@ -66,7 +66,7 @@ public class MixtapeService {
         this.mixtapeRepository.deleteById(id);
     }
 
-    public Mixtape findById(String id) {
+    public Mixtape findByIdForAuthenticatedUser(String id) {
         User user = this.userService.getAuthenticatedUser()
                 .orElseThrow(UnauthorizedException::new);
 

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/TrackService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/TrackService.java
@@ -15,19 +15,19 @@ public class TrackService {
     private final MixtapeService mixtapeService;
 
     public Track saveForMixtape(String mixtapeId, Track track) {
-        Mixtape mixtape = this.mixtapeService.findById(mixtapeId);
+        Mixtape mixtape = this.mixtapeService.findByIdForAuthenticatedUser(mixtapeId);
 
         Track savedTrack = this.trackRepository.save(track);
 
         mixtape.getTracks().add(track);
-        this.mixtapeService.updateById(mixtape.getId(), mixtape);
+        this.mixtapeService.updateByIdForAuthenticatedUser(mixtape.getId(), mixtape);
 
         return savedTrack;
     }
 
     public Track updateByIdForMixtape(String mixtapeId, String id, Track track) {
         track.setId(id);
-        Mixtape mixtape = this.mixtapeService.findById(mixtapeId);
+        Mixtape mixtape = this.mixtapeService.findByIdForAuthenticatedUser(mixtapeId);
 
         if (!mixtape.hasTrackWithId(track.getId()) || !this.trackRepository.existsById(id)) {
             throw new NotFoundException();
@@ -37,7 +37,7 @@ public class TrackService {
     }
 
     public void deleteByIdForMixtape(String mixtapeId, String id) {
-        Mixtape mixtape = this.mixtapeService.findById(mixtapeId);
+        Mixtape mixtape = this.mixtapeService.findByIdForAuthenticatedUser(mixtapeId);
 
         if (!mixtape.hasTrackWithId(id) || !this.trackRepository.existsById(id)) {
             throw new NotFoundException();
@@ -46,6 +46,6 @@ public class TrackService {
         this.trackRepository.deleteById(id);
 
         mixtape.removeTrackWithId(id);
-        this.mixtapeService.updateById(mixtape.getId(), mixtape);
+        this.mixtapeService.updateByIdForAuthenticatedUser(mixtape.getId(), mixtape);
     }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/validation/MixtapeExists.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/validation/MixtapeExists.java
@@ -1,0 +1,17 @@
+package com.github.chuettenrauch.mixifyapi.mixtape.validation;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.validation.validator.MixtapeExistsValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MixtapeExistsValidator.class)
+@Documented
+public @interface MixtapeExists {
+    String message() default "mixtape does not exist";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/validation/validator/MixtapeExistsValidator.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/validation/validator/MixtapeExistsValidator.java
@@ -1,0 +1,23 @@
+package com.github.chuettenrauch.mixifyapi.mixtape.validation.validator;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import com.github.chuettenrauch.mixifyapi.mixtape.validation.MixtapeExists;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MixtapeExistsValidator implements ConstraintValidator<MixtapeExists, String> {
+
+    private final MixtapeService mixtapeService;
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+
+        return this.mixtapeService.existsById(value);
+    }
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,3 +39,5 @@ app:
   oauth2:
     success-redirect-uri: "${OAUTH2_SUCCESS_REDIRECT_URI:http://localhost:3000}"
     failure-redirect-uri: "${OAUTH2_FAILURE_REDIRECT_URI:http://localhost:3000/login}"
+  invite:
+    expiration-time: "PT1H"

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/config/AppPropertiesTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/config/AppPropertiesTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         properties = {
             "app.o-auth2.success-redirect-uri=/success",
             "app.o-auth2.failure-redirect-uri=/failure",
+            "app.invite.expiration-time=PT1H",
         }
 )
 @TestPropertySource(properties = "spring.autoconfigure.exclude=de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration")
@@ -25,9 +26,11 @@ class AppPropertiesTest {
     @Test
     void correctlyBindsPropertiesToAppConfig() {
         AppProperties.OAuth2 oauth2 = appProperties.getOAuth2();
+        AppProperties.Invite invite = appProperties.getInvite();
 
         assertEquals("/success", oauth2.getSuccessRedirectUri());
         assertEquals("/failure", oauth2.getFailureRedirectUri());
+        assertEquals("PT1H", invite.getExpirationTime());
     }
 
     @EnableConfigurationProperties(AppProperties.class)

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/invite/controller/InviteControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/invite/controller/InviteControllerTest.java
@@ -1,0 +1,101 @@
+package com.github.chuettenrauch.mixifyapi.integration.invite.controller;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.repository.MixtapeRepository;
+import com.github.chuettenrauch.mixifyapi.user.model.Provider;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.repository.UserRepository;
+import com.github.chuettenrauch.mixifyapi.utils.TestUserHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class InviteControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private MixtapeRepository mixtapeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private TestUserHelper testUserHelper;
+
+    @BeforeEach
+    void setup() {
+        this.testUserHelper = new TestUserHelper(this.userRepository);
+    }
+
+    @Test
+    @DirtiesContext
+    void create_whenLoggedIn_thenReturnInvite() throws Exception {
+        // given
+        User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
+        OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
+
+        Mixtape mixtape = new Mixtape("123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user);
+        this.mixtapeRepository.save(mixtape);
+
+        String givenJson = """
+                {
+                    "mixtape": "123"
+                }
+                """;
+
+        // when + then
+        this.mvc.perform(post("/api/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(givenJson)
+                        .with(oauth2Login().oauth2User(oAuth2User))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(content().json(givenJson))
+                .andExpect(jsonPath("$.id", notNullValue()))
+                .andExpect(jsonPath("$.expiredAt", notNullValue()));
+    }
+
+    @Test
+    @DirtiesContext
+    void create_whenGivenJsonHasId_thenReturnUnprocessableEntity() throws Exception {
+        // given
+        User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
+        OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
+
+        Mixtape mixtape = new Mixtape("123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user);
+        this.mixtapeRepository.save(mixtape);
+
+        String givenJson = """
+                {
+                    "id": "123",
+                    "mixtape": "123"
+                }
+                """;
+
+        // when + then
+        this.mvc.perform(post("/api/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(givenJson)
+                        .with(oauth2Login().oauth2User(oAuth2User))
+                )
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/invite/service/InviteServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/invite/service/InviteServiceTest.java
@@ -1,0 +1,65 @@
+package com.github.chuettenrauch.mixifyapi.unit.invite.service;
+
+import com.github.chuettenrauch.mixifyapi.config.AppProperties;
+import com.github.chuettenrauch.mixifyapi.exception.UnprocessableEntityException;
+import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
+import com.github.chuettenrauch.mixifyapi.invite.repository.InviteRepository;
+import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+
+class InviteServiceTest {
+
+    @Test
+    void save_whenCalled_thenDelegateToInviteRepository() {
+        // given
+        Invite given = new Invite();
+        given.setMixtape(new Mixtape());
+
+        InviteRepository inviteRepository = mock(InviteRepository.class);
+        when(inviteRepository.save(given)).thenReturn(given);
+
+        AppProperties.Invite inviteProperties = mock(AppProperties.Invite.class);
+        when(inviteProperties.getExpirationTime()).thenReturn("PT5H");
+
+        // when
+        InviteService sut = new InviteService(inviteRepository, inviteProperties);
+
+        LocalDateTime beforeCreate = LocalDateTime.now();
+        Invite actual = sut.save(given);
+        LocalDateTime afterCreate = LocalDateTime.now();
+
+        // then
+        assertEquals(given.getMixtape(), actual.getMixtape());
+        assertThat(actual.getExpiredAt())
+                .isAfter(beforeCreate.plusHours(5))
+                .isBefore(afterCreate.plusHours(5));
+
+        verify(inviteRepository).save(any());
+    }
+
+    @Test
+    void save_whenInviteHasId_thenThrowUnprocessableEntityException() {
+        // given
+        Invite invite = new Invite();
+        invite.setId("123");
+        invite.setMixtape(new Mixtape());
+
+        InviteRepository inviteRepository = mock(InviteRepository.class);
+        AppProperties.Invite inviteProperties = mock(AppProperties.Invite.class);
+
+        // when
+        InviteService sut = new InviteService(inviteRepository, inviteProperties);
+        assertThrows(UnprocessableEntityException.class, () -> sut.save(invite));
+
+        // then
+        verify(inviteRepository, never()).save(invite);
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/invite/service/InviteServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/invite/service/InviteServiceTest.java
@@ -5,7 +5,6 @@ import com.github.chuettenrauch.mixifyapi.exception.UnprocessableEntityException
 import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
 import com.github.chuettenrauch.mixifyapi.invite.repository.InviteRepository;
 import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
-import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -21,7 +20,7 @@ class InviteServiceTest {
     void save_whenCalled_thenDelegateToInviteRepository() {
         // given
         Invite given = new Invite();
-        given.setMixtape(new Mixtape());
+        given.setMixtape("abc123");
 
         InviteRepository inviteRepository = mock(InviteRepository.class);
         when(inviteRepository.save(given)).thenReturn(given);
@@ -29,8 +28,11 @@ class InviteServiceTest {
         AppProperties.Invite inviteProperties = mock(AppProperties.Invite.class);
         when(inviteProperties.getExpirationTime()).thenReturn("PT5H");
 
+        AppProperties appProperties = mock(AppProperties.class);
+        when(appProperties.getInvite()).thenReturn(inviteProperties);
+
         // when
-        InviteService sut = new InviteService(inviteRepository, inviteProperties);
+        InviteService sut = new InviteService(inviteRepository, appProperties);
 
         LocalDateTime beforeCreate = LocalDateTime.now();
         Invite actual = sut.save(given);
@@ -50,13 +52,13 @@ class InviteServiceTest {
         // given
         Invite invite = new Invite();
         invite.setId("123");
-        invite.setMixtape(new Mixtape());
+        invite.setMixtape("abc123");
 
         InviteRepository inviteRepository = mock(InviteRepository.class);
-        AppProperties.Invite inviteProperties = mock(AppProperties.Invite.class);
+        AppProperties appProperties = mock(AppProperties.class);
 
         // when
-        InviteService sut = new InviteService(inviteRepository, inviteProperties);
+        InviteService sut = new InviteService(inviteRepository, appProperties);
         assertThrows(UnprocessableEntityException.class, () -> sut.save(invite));
 
         // then

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/controller/InviteControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/controller/InviteControllerTest.java
@@ -2,6 +2,7 @@ package com.github.chuettenrauch.mixifyapi.unit.mixtape.controller;
 
 import com.github.chuettenrauch.mixifyapi.invite.controller.InviteController;
 import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
 import com.github.chuettenrauch.mixifyapi.security.config.SecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,6 +33,9 @@ class InviteControllerTest {
 
     @MockBean
     private InviteService inviteService;
+
+    @MockBean
+    private MixtapeService mixtapeService;
 
     @Test
     void create_whenNotLoggedIn_thenReturnUnauthorized() throws Exception {

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/controller/InviteControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/controller/InviteControllerTest.java
@@ -1,0 +1,79 @@
+package com.github.chuettenrauch.mixifyapi.unit.mixtape.controller;
+
+import com.github.chuettenrauch.mixifyapi.invite.controller.InviteController;
+import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
+import com.github.chuettenrauch.mixifyapi.security.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InviteController.class)
+@ImportAutoConfiguration(classes = SecurityConfig.class)
+class InviteControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private InviteService inviteService;
+
+    @Test
+    void create_whenNotLoggedIn_thenReturnUnauthorized() throws Exception {
+        this.mvc.perform(post("/api/invites"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidInviteJson")
+    void create_whenInvalidJson_thenReturnBadRequest(String givenJson, String expectedJson) throws Exception {
+        this.mvc.perform(post("/api/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(givenJson)
+                        .with(oauth2Login())
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(expectedJson, true));
+    }
+
+    private static Stream<Arguments> provideInvalidInviteJson() {
+        return Stream.of(
+                arguments(named("mixtape | missing", """
+                                    {
+                                    }
+                                """),
+                        """
+                                {
+                                    "mixtape": "must not be blank"
+                                }
+                                """
+                ),
+                arguments(named("mixtape | not found", """
+                                    {
+                                        "mixtape": "does-not-exist"
+                                    }
+                                """),
+                        """
+                                {
+                                    "mixtape": "mixtape does not exist"
+                                }
+                                """
+                )
+        );
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
@@ -102,7 +102,7 @@ class MixtapeServiceTest {
     }
 
     @Test
-    void deleteById_whenNotLoggedIn_thenThrowUnauthorizedException() {
+    void deleteByIdForAuthenticatedUser_whenNotLoggedIn_thenThrowUnauthorizedException() {
         // given
         String id = "123";
         MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
@@ -114,14 +114,14 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        assertThrows(UnauthorizedException.class, () -> sut.deleteById(id));
+        assertThrows(UnauthorizedException.class, () -> sut.deleteByIdForAuthenticatedUser(id));
 
         // then
         verify(mixtapeRepository, never()).deleteById(any());
     }
 
     @Test
-    void deleteById_whenMixtapeDoesNotExistOrDoesNotBelongToUser_thenThrowNotFoundException() {
+    void deleteByIdForAuthenticatedUser_whenMixtapeDoesNotExistOrDoesNotBelongToUser_thenThrowNotFoundException() {
         // given
         String id = "123";
         User user = new User();
@@ -136,14 +136,14 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        assertThrows(NotFoundException.class, () -> sut.deleteById("123"));
+        assertThrows(NotFoundException.class, () -> sut.deleteByIdForAuthenticatedUser("123"));
 
         // then
         verify(mixtapeRepository, never()).deleteById(any());
     }
 
     @Test
-    void deleteById_whenMixtapeExistsAndBelongsToUser_thenDeleteMixtape() {
+    void deleteByIdForAuthenticatedUser_whenMixtapeExistsAndBelongsToUser_thenDeleteMixtape() {
         // given
         User user = new User();
 
@@ -160,14 +160,14 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        sut.deleteById(mixtape.getId());
+        sut.deleteByIdForAuthenticatedUser(mixtape.getId());
 
         // then
         verify(mixtapeRepository).deleteById(mixtape.getId());
     }
 
     @Test
-    void updateById_whenNotLoggedIn_thenThrowUnauthorizedException() {
+    void updateByIdForAuthenticatedUser_whenNotLoggedIn_thenThrowUnauthorizedException() {
         // given
         String id = "123";
         Mixtape mixtape = new Mixtape();
@@ -181,14 +181,14 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        assertThrows(UnauthorizedException.class, () -> sut.updateById(id, mixtape));
+        assertThrows(UnauthorizedException.class, () -> sut.updateByIdForAuthenticatedUser(id, mixtape));
 
         // then
         verify(mixtapeRepository, never()).save(any());
     }
 
     @Test
-    void updateById_whenMixtapeDoesNotExistOrDoesNotBelongToLoggedInUser_thenThrowNotFoundException() {
+    void updateByIdForAuthenticatedUser_whenMixtapeDoesNotExistOrDoesNotBelongToLoggedInUser_thenThrowNotFoundException() {
         // given
         String id = "123";
         Mixtape mixtape = new Mixtape();
@@ -204,14 +204,14 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        assertThrows(NotFoundException.class, () -> sut.updateById(id, mixtape));
+        assertThrows(NotFoundException.class, () -> sut.updateByIdForAuthenticatedUser(id, mixtape));
 
         // then
         verify(mixtapeRepository, never()).save(any());
     }
 
     @Test
-    void updateById_whenMixtapeExists_thenEnsureIdFromUrlAndUpdateMixtape() {
+    void updateByIdForAuthenticatedUser_whenMixtapeExists_thenEnsureIdFromUrlAndUpdateMixtape() {
         // given
         String expectedId = "id-from-url";
 
@@ -234,7 +234,7 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        Mixtape actual = sut.updateById(expectedId, mixtape);
+        Mixtape actual = sut.updateByIdForAuthenticatedUser(expectedId, mixtape);
 
         // then
         assertEquals(actual, expectedMixtape);
@@ -242,7 +242,7 @@ class MixtapeServiceTest {
     }
 
     @Test
-    void updateById_whenNumOfTracksExceedsMaxLimit_thenThrowConstraintViolationException() {
+    void updateByIdForAuthenticatedUser_whenNumOfTracksExceedsMaxLimit_thenThrowConstraintViolationException() {
         // given
         String mixtapeId = "123";
 
@@ -264,14 +264,14 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        assertThrows(ConstraintViolationException.class, () -> sut.updateById(mixtapeId, mixtape));
+        assertThrows(ConstraintViolationException.class, () -> sut.updateByIdForAuthenticatedUser(mixtapeId, mixtape));
 
         // then
         verify(mixtapeRepository, never()).save(mixtape);
     }
 
     @Test
-    void getById_whenNotLoggedIn_thenThrowUnauthorizedException() {
+    void getByIdForAuthenticatedUser_whenNotLoggedIn_thenThrowUnauthorizedException() {
         // given
         UserService userService = mock(UserService.class);
         when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
@@ -282,14 +282,14 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        assertThrows(UnauthorizedException.class, () -> sut.findById("123"));
+        assertThrows(UnauthorizedException.class, () -> sut.findByIdForAuthenticatedUser("123"));
 
         // then
         verify(mixtapeRepository, never()).findByIdAndCreatedBy(any(), any());
     }
 
     @Test
-    void getById_whenMixtapeNotFoundOrDoesNotBelongToUser_thenThrowNotFoundException() {
+    void getByIdForAuthenticatedUser_whenMixtapeNotFoundOrDoesNotBelongToUser_thenThrowNotFoundException() {
         // given
         String id = "123";
         User user = new User();
@@ -304,14 +304,14 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        assertThrows(NotFoundException.class, () -> sut.findById(id));
+        assertThrows(NotFoundException.class, () -> sut.findByIdForAuthenticatedUser(id));
 
         // then
         verify(mixtapeRepository).findByIdAndCreatedBy(id, user);
     }
 
     @Test
-    void getById_whenLoggedInAndMixtapeBelongsToUser_thenReturnMixtape() {
+    void getByIdForAuthenticatedUser_whenLoggedInAndMixtapeBelongsToUser_thenReturnMixtape() {
         // given
         String id = "123";
         User user = new User();
@@ -327,7 +327,7 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
-        Mixtape actual = sut.findById(id);
+        Mixtape actual = sut.findByIdForAuthenticatedUser(id);
 
         // then
         assertEquals(expected, actual);

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
@@ -334,6 +334,28 @@ class MixtapeServiceTest {
         verify(mixtapeRepository).findByIdAndCreatedBy(id, user);
     }
 
+    @Test
+    void existsById_whenCalled_thenDelegatesToMixtapeRepository() {
+        // given
+        String id = "123";
+        boolean expected = true;
+
+        UserService userService = mock(UserService.class);
+
+        MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
+        when(mixtapeRepository.existsById(id)).thenReturn(expected);
+
+        Validator validator = mock(Validator.class);
+
+        // when
+        MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
+        boolean actual = sut.existsById(id);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeRepository).existsById(id);
+    }
+
     /**
      * This is only to overcome the issue, that it is not possible to mock classes with generic parameters
      */

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/TrackServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/TrackServiceTest.java
@@ -25,7 +25,7 @@ class TrackServiceTest {
         TrackRepository trackRepository = mock(TrackRepository.class);
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenThrow(UnauthorizedException.class);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenThrow(UnauthorizedException.class);
 
         // when
         TrackService sut = new TrackService(trackRepository, mixtapeService);
@@ -44,7 +44,7 @@ class TrackServiceTest {
         TrackRepository trackRepository = mock(TrackRepository.class);
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenThrow(NotFoundException.class);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenThrow(NotFoundException.class);
 
         // when
         TrackService sut = new TrackService(trackRepository, mixtapeService);
@@ -67,7 +67,7 @@ class TrackServiceTest {
         mixtapeWithTrackAdded.setTracks(List.of(track));
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtape.getId())).thenReturn(mixtape);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtape.getId())).thenReturn(mixtape);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
         when(trackRepository.save(track)).thenReturn(track);
@@ -80,7 +80,7 @@ class TrackServiceTest {
         assertEquals(track, actual);
 
         verify(trackRepository).save(track);
-        verify(mixtapeService).updateById(mixtapeWithTrackAdded.getId(), mixtapeWithTrackAdded);
+        verify(mixtapeService).updateByIdForAuthenticatedUser(mixtapeWithTrackAdded.getId(), mixtapeWithTrackAdded);
     }
 
     @Test
@@ -93,7 +93,7 @@ class TrackServiceTest {
         track.setId(trackId);
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenThrow(UnauthorizedException.class);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenThrow(UnauthorizedException.class);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
 
@@ -115,7 +115,7 @@ class TrackServiceTest {
         track.setId(trackId);
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenThrow(NotFoundException.class);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenThrow(NotFoundException.class);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
 
@@ -140,7 +140,7 @@ class TrackServiceTest {
         mixtapeWithTrack.setTracks(List.of(track));
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenReturn(mixtapeWithTrack);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenReturn(mixtapeWithTrack);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
         when(trackRepository.existsById(track.getId())).thenReturn(false);
@@ -163,7 +163,7 @@ class TrackServiceTest {
         track.setId(trackId);
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenReturn(new Mixtape());
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenReturn(new Mixtape());
 
         TrackRepository trackRepository = mock(TrackRepository.class);
 
@@ -191,7 +191,7 @@ class TrackServiceTest {
         mixtapeWithTrack.setTracks(List.of(expectedTrack));
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
         when(trackRepository.existsById(trackIdFromUrl)).thenReturn(true);
@@ -213,7 +213,7 @@ class TrackServiceTest {
         String mixtapeId = "123";
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenThrow(UnauthorizedException.class);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenThrow(UnauthorizedException.class);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
 
@@ -232,7 +232,7 @@ class TrackServiceTest {
         String mixtapeId = "123";
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenThrow(NotFoundException.class);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenThrow(NotFoundException.class);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
 
@@ -258,7 +258,7 @@ class TrackServiceTest {
         mixtapeWithTrack.setTracks(List.of(track));
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
         when(trackRepository.existsById(track.getId())).thenReturn(false);
@@ -278,7 +278,7 @@ class TrackServiceTest {
         String mixtapeId = "123";
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeId)).thenReturn(new Mixtape());
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeId)).thenReturn(new Mixtape());
 
         TrackRepository trackRepository = mock(TrackRepository.class);
 
@@ -301,7 +301,7 @@ class TrackServiceTest {
         mixtapeWithTrack.setTracks(List.of(track));
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
+        when(mixtapeService.findByIdForAuthenticatedUser(mixtapeWithTrack.getId())).thenReturn(mixtapeWithTrack);
 
         TrackRepository trackRepository = mock(TrackRepository.class);
         when(trackRepository.existsById(track.getId())).thenReturn(true);
@@ -312,6 +312,6 @@ class TrackServiceTest {
 
         // then
         verify(trackRepository).deleteById(track.getId());
-        verify(mixtapeService).updateById(mixtapeWithTrack.getId(), mixtapeWithTrack);
+        verify(mixtapeService).updateByIdForAuthenticatedUser(mixtapeWithTrack.getId(), mixtapeWithTrack);
     }
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/validation/validator/MixtapeExistsValidatorTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/validation/validator/MixtapeExistsValidatorTest.java
@@ -1,0 +1,62 @@
+package com.github.chuettenrauch.mixifyapi.unit.mixtape.validation.validator;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import com.github.chuettenrauch.mixifyapi.mixtape.validation.validator.MixtapeExistsValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MixtapeExistsValidatorTest {
+
+    @Test
+    void isValid_whenMixtapeExists_thenReturnTrue() {
+        // given
+        String mixtapeId = "abc123";
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.existsById(mixtapeId)).thenReturn(true);
+
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+
+        // when
+        MixtapeExistsValidator sut = new MixtapeExistsValidator(mixtapeService);
+        boolean actual = sut.isValid(mixtapeId, context);
+
+        // then
+        assertTrue(actual);
+    }
+
+    @Test
+    void isValid_whenMixtapeDoesNotExist_thenReturnFalse() {
+        // given
+        String mixtapeId = "abc123";
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.existsById(mixtapeId)).thenReturn(false);
+
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+
+        // when
+        MixtapeExistsValidator sut = new MixtapeExistsValidator(mixtapeService);
+        boolean actual = sut.isValid(mixtapeId, context);
+
+        // then
+        assertFalse(actual);
+    }
+
+    @Test
+    void isValid_whenMixtapeBlank_thenReturnTrue() {
+        // given
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+
+        // when
+        MixtapeExistsValidator sut = new MixtapeExistsValidator(mixtapeService);
+
+        assertTrue(sut.isValid("", context));
+        assertTrue(sut.isValid(null, context));
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -28,3 +28,5 @@ app:
   oauth2:
     success-redirect-uri: "/"
     failure-redirect-uri: "/login"
+  invite:
+    expiration-time: "PT1H"


### PR DESCRIPTION
- `POST /api/invites` endpoint, that takes a mixtape ID and creates an entry in the `invite` collection
- the invite has an `expiredAt` date "now + 1 hour"