### PR TITLE
GH-101 - make it possible to pass redirect url from react to spring during login

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1.1
   workflow_call:
     secrets:
       SONAR_TOKEN_FRONTEND:

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/config/SecurityConfig.java
@@ -2,11 +2,16 @@ package com.github.chuettenrauch.mixifyapi.security.config;
 
 import com.github.chuettenrauch.mixifyapi.config.AppProperties;
 import com.github.chuettenrauch.mixifyapi.security.oauth2.OAuth2AuthenticationFailureHandler;
+import com.github.chuettenrauch.mixifyapi.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import com.github.chuettenrauch.mixifyapi.security.oauth2.AuthorizationRequestRepositoryDecorator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -31,6 +36,9 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(config -> config
+                                .authorizationRequestRepository(authorizationRequestRepository())
+                        )
                         .redirectionEndpoint(config -> config
                                 .baseUri("/oauth2/code/*")
                         )
@@ -52,7 +60,11 @@ public class SecurityConfig {
     }
 
     private AuthenticationSuccessHandler authenticationSuccessHandler(String redirectUri) {
-        return new SimpleUrlAuthenticationSuccessHandler(redirectUri);
+        return new OAuth2AuthenticationSuccessHandler(redirectUri);
+    }
+
+    private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+        return new AuthorizationRequestRepositoryDecorator(new HttpSessionOAuth2AuthorizationRequestRepository());
     }
 
     private AuthenticationFailureHandler authenticationFailureHandler(String redirectUri) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/oauth2/AuthorizationRequestRepositoryDecorator.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/oauth2/AuthorizationRequestRepositoryDecorator.java
@@ -1,0 +1,52 @@
+package com.github.chuettenrauch.mixifyapi.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+@RequiredArgsConstructor
+public class AuthorizationRequestRepositoryDecorator implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String REDIRECT_URL_PARAM = "redirect_url";
+    private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return this.authorizationRequestRepository.loadAuthorizationRequest(request);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        String redirectUrl = request.getParameter(REDIRECT_URL_PARAM);
+
+        if (this.isValidUrl(redirectUrl)) {
+            request.getSession().setAttribute(
+                    OAuth2AuthenticationSuccessHandler.REDIRECT_URL_SESSION_PARAM,
+                    redirectUrl
+            );
+        }
+
+        this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest, request, response);
+    }
+
+    private boolean isValidUrl(String url) {
+        try {
+            new URL(url).toURI();
+        } catch (MalformedURLException | URISyntaxException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        return this.authorizationRequestRepository.removeAuthorizationRequest(request, response);
+    }
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,29 @@
+package com.github.chuettenrauch.mixifyapi.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    public static final String REDIRECT_URL_SESSION_PARAM = "authenticationSuccessRedirectUrl";
+
+    public OAuth2AuthenticationSuccessHandler(String defaultTargetUrl) {
+        super(defaultTargetUrl);
+    }
+
+    @Override
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
+        HttpSession session = request.getSession();
+        String redirectUrl = (String) session.getAttribute(REDIRECT_URL_SESSION_PARAM);
+
+        if (redirectUrl == null) {
+            return super.determineTargetUrl(request, response);
+        }
+
+        session.removeAttribute(REDIRECT_URL_SESSION_PARAM);
+
+        return redirectUrl;
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/security/oauth2/AuthorizationRequestRepositoryDecoratorTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/security/oauth2/AuthorizationRequestRepositoryDecoratorTest.java
@@ -1,0 +1,137 @@
+package com.github.chuettenrauch.mixifyapi.unit.security.oauth2;
+
+import com.github.chuettenrauch.mixifyapi.security.oauth2.AuthorizationRequestRepositoryDecorator;
+import com.github.chuettenrauch.mixifyapi.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.*;
+
+class AuthorizationRequestRepositoryDecoratorTest {
+
+    @Test
+    void loadAuthorizationRequest_whenCalled_thenDelegateToDecoratedAuthorizationRequestRepository() {
+        // given
+        OAuth2AuthorizationRequest expected = this.createOAuth2AuthorizationRequest();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = mock(AuthorizationRequestRepositoryStub.class);
+        when(authorizationRequestRepository.loadAuthorizationRequest(request)).thenReturn(expected);
+
+        // when
+        AuthorizationRequestRepositoryDecorator sut = new AuthorizationRequestRepositoryDecorator(authorizationRequestRepository);
+        OAuth2AuthorizationRequest actual = sut.loadAuthorizationRequest(request);
+
+        // then
+        assertEquals(expected, actual);
+        verify(authorizationRequestRepository).loadAuthorizationRequest(request);
+    }
+
+    @Test
+    void saveAuthorizationRequest_whenRedirectUrlIsInRequest_thenSaveToSessionAndDelegateToDecoratedAuthorizationRequestRepository() {
+        // given
+        String redirectUrl = "http://some-url";
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest = this.createOAuth2AuthorizationRequest();
+
+        HttpSession httpSession = mock(HttpSession.class);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("redirect_url")).thenReturn(redirectUrl);
+        when(request.getSession()).thenReturn(httpSession);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = mock(AuthorizationRequestRepositoryStub.class);
+
+        // when
+        AuthorizationRequestRepositoryDecorator sut = new AuthorizationRequestRepositoryDecorator(authorizationRequestRepository);
+        sut.saveAuthorizationRequest(oAuth2AuthorizationRequest, request, response);
+
+        // then
+        verify(httpSession).setAttribute(OAuth2AuthenticationSuccessHandler.REDIRECT_URL_SESSION_PARAM, redirectUrl);
+        verify(authorizationRequestRepository).saveAuthorizationRequest(oAuth2AuthorizationRequest, request, response);
+    }
+
+    @ParameterizedTest
+    @MethodSource("providerInvalidRedirectUrl")
+    void saveAuthorizationRequest_whenRedirectUrlInvalid_thenOnlyDelegateToDecoratedAuthorizationRequestRepository(
+            String redirectUrl
+    ) {
+        // given
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest = this.createOAuth2AuthorizationRequest();
+
+        HttpSession httpSession = mock(HttpSession.class);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("redirect_url")).thenReturn(redirectUrl);
+        when(request.getSession()).thenReturn(httpSession);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = mock(AuthorizationRequestRepositoryStub.class);
+
+        // when
+        AuthorizationRequestRepositoryDecorator sut = new AuthorizationRequestRepositoryDecorator(authorizationRequestRepository);
+        sut.saveAuthorizationRequest(oAuth2AuthorizationRequest, request, response);
+
+        // then
+        verify(httpSession, never()).setAttribute(any(), any());
+        verify(authorizationRequestRepository).saveAuthorizationRequest(oAuth2AuthorizationRequest, request, response);
+    }
+
+    private static Stream<Arguments> providerInvalidRedirectUrl() {
+        return Stream.of(
+                arguments(named("redirect_url | missing", null)),
+                arguments(named("redirect_url | empty", "")),
+                arguments(named("redirect_url | invalid url", "some-invalid-url"))
+        );
+    }
+
+    @Test
+    void removeAuthorizationRequest_whenCalled_thenDelegateToDecoratedAuthorizationRequestRepository() {
+        // given
+        OAuth2AuthorizationRequest expected = this.createOAuth2AuthorizationRequest();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = mock(AuthorizationRequestRepositoryStub.class);
+        when(authorizationRequestRepository.removeAuthorizationRequest(request, response)).thenReturn(expected);
+
+        // when
+        AuthorizationRequestRepositoryDecorator sut = new AuthorizationRequestRepositoryDecorator(authorizationRequestRepository);
+        OAuth2AuthorizationRequest actual = sut.removeAuthorizationRequest(request, response);
+
+        // then
+        assertEquals(expected, actual);
+        verify(authorizationRequestRepository).removeAuthorizationRequest(request, response);
+    }
+
+    private OAuth2AuthorizationRequest createOAuth2AuthorizationRequest() {
+        return OAuth2AuthorizationRequest
+                .authorizationCode()
+                .authorizationUri("some-uri")
+                .clientId("client-id")
+                .state("state123")
+                .redirectUri("http://localhost")
+                .build();
+    }
+
+    /**
+     * This is only to overcome the issue, that it is not possible to mock classes with generic parameters
+     */
+    private interface AuthorizationRequestRepositoryStub extends AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,72 @@
+package com.github.chuettenrauch.mixifyapi.unit.security.oauth2;
+
+import com.github.chuettenrauch.mixifyapi.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.RedirectStrategy;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+class OAuth2AuthenticationSuccessHandlerTest {
+
+    @Test
+    void onAuthenticationSuccess_whenRedirectUrlInSession_thenRedirectToIt() throws ServletException, IOException {
+        // given
+        String redirectUrl = "http://redirect";
+
+        HttpSession httpSession = mock(HttpSession.class);
+        when(httpSession.getAttribute(OAuth2AuthenticationSuccessHandler.REDIRECT_URL_SESSION_PARAM))
+                .thenReturn(redirectUrl);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession()).thenReturn(httpSession);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        Authentication authentication = mock(Authentication.class);
+
+        RedirectStrategy redirectStrategy = mock(RedirectStrategy.class);
+
+        // when
+        OAuth2AuthenticationSuccessHandler sut = new OAuth2AuthenticationSuccessHandler("/does-not-matter");
+        sut.setRedirectStrategy(redirectStrategy);
+
+        sut.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        verify(redirectStrategy).sendRedirect(request, response, redirectUrl);
+        verify(httpSession).removeAttribute(OAuth2AuthenticationSuccessHandler.REDIRECT_URL_SESSION_PARAM);
+    }
+
+    @Test
+    void onAuthenticationSuccess_whenRedirectUrlNotInSession_thenRedirectToDefaultTargetUrl() throws ServletException, IOException {
+        // given
+        String defaultTargetUrl = "http://default";
+
+        HttpSession httpSession = mock(HttpSession.class);
+        when(httpSession.getAttribute(OAuth2AuthenticationSuccessHandler.REDIRECT_URL_SESSION_PARAM))
+                .thenReturn(null);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession()).thenReturn(httpSession);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        Authentication authentication = mock(Authentication.class);
+
+        RedirectStrategy redirectStrategy = mock(RedirectStrategy.class);
+
+        // when
+        OAuth2AuthenticationSuccessHandler sut = new OAuth2AuthenticationSuccessHandler(defaultTargetUrl);
+        sut.setRedirectStrategy(redirectStrategy);
+
+        sut.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        verify(redirectStrategy).sendRedirect(request, response, defaultTargetUrl);
+    }
+}


### PR DESCRIPTION
- store redirect_url, that is passed from react to authorize endpoint in session
- reload it from session and redirect to it, after authentication with spotify account was successful