### PR TITLE
GH-105 - put endpoint to accept an invite

### DIFF
--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/exception/GoneException.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/exception/GoneException.java
@@ -1,0 +1,8 @@
+package com.github.chuettenrauch.mixifyapi.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.GONE)
+public class GoneException extends RuntimeException {
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/controller/InviteController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/controller/InviteController.java
@@ -2,6 +2,7 @@ package com.github.chuettenrauch.mixifyapi.invite.controller;
 
 import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
 import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
+import com.github.chuettenrauch.mixifyapi.mixtapeUser.model.MixtapeUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,5 +19,10 @@ public class InviteController {
     @ResponseStatus(HttpStatus.CREATED)
     public Invite create(@RequestBody @Valid Invite invite) {
         return this.inviteService.save(invite);
+    }
+
+    @PutMapping("/{id}")
+    public MixtapeUser acceptInvite(@PathVariable String id) {
+        return this.inviteService.acceptInviteByIdForAuthenticatedUser(id);
     }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/invite/model/Invite.java
@@ -27,4 +27,10 @@ public class Invite {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime expiredAt;
 
+    public boolean isExpired() {
+        LocalDateTime now = LocalDateTime.now();
+
+        return now.isAfter(expiredAt) || now.isEqual(expiredAt);
+    }
+
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -74,6 +74,11 @@ public class MixtapeService {
                 .orElseThrow(NotFoundException::new);
     }
 
+    public Mixtape findById(String id) {
+        return this.mixtapeRepository.findById(id)
+                .orElseThrow(NotFoundException::new);
+    }
+
     public boolean existsById(String id) {
         return this.mixtapeRepository.existsById(id);
     }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtapeUser/model/MixtapeUser.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtapeUser/model/MixtapeUser.java
@@ -1,0 +1,26 @@
+package com.github.chuettenrauch.mixifyapi.mixtapeUser.model;
+
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.DocumentReference;
+
+@Document
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MixtapeUser {
+
+    @Id
+    private String id;
+
+    @DocumentReference
+    private User user;
+
+    @DocumentReference
+    private Mixtape mixtape;
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtapeUser/repository/MixtapeUserRepository.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtapeUser/repository/MixtapeUserRepository.java
@@ -1,0 +1,9 @@
+package com.github.chuettenrauch.mixifyapi.mixtapeUser.repository;
+
+import com.github.chuettenrauch.mixifyapi.mixtapeUser.model.MixtapeUser;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MixtapeUserRepository extends MongoRepository<MixtapeUser, String> {
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtapeUser/service/MixtapeUserService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtapeUser/service/MixtapeUserService.java
@@ -1,0 +1,32 @@
+package com.github.chuettenrauch.mixifyapi.mixtapeUser.service;
+
+import com.github.chuettenrauch.mixifyapi.exception.UnauthorizedException;
+import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import com.github.chuettenrauch.mixifyapi.mixtapeUser.model.MixtapeUser;
+import com.github.chuettenrauch.mixifyapi.mixtapeUser.repository.MixtapeUserRepository;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MixtapeUserService {
+
+    private final MixtapeUserRepository mixtapeUserRepository;
+
+    private final MixtapeService mixtapeService;
+
+    private final UserService userService;
+
+    public MixtapeUser createFromInviteForAuthenticatedUser(Invite invite) {
+        User user = this.userService.getAuthenticatedUser().orElseThrow(UnauthorizedException::new);
+        Mixtape mixtape = this.mixtapeService.findById(invite.getMixtape());
+
+        MixtapeUser mixtapeUser = new MixtapeUser(null, user, mixtape);
+
+        return this.mixtapeUserRepository.save(mixtapeUser);
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/file/controller/FileControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/file/controller/FileControllerTest.java
@@ -38,27 +38,6 @@ class FileControllerTest {
     private FileService fileService;
 
     @Test
-    void uploadFile_whenNotLoggedIn_returnUnauthorized() throws Exception {
-        MockMultipartFile file = new MockMultipartFile("file", "image.jpg", "image/jpeg", "some image".getBytes());
-
-        this.mvc.perform(multipart("/api/files")
-                        .file(file)
-                )
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void uploadFile_whenLoggedInButUserDoesNotExistInDB_returnUnauthorized() throws Exception {
-        MockMultipartFile file = new MockMultipartFile("file", "file.txt", "text/plain", "some image".getBytes());
-
-        this.mvc.perform(multipart("/api/files")
-                        .file(file)
-                        .with(oauth2Login())
-                )
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
     void uploadFile_whenLoggedInButFileIsEmpty_returnBadRequest() throws Exception {
         // given
         User user = new User("123", "user", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -99,20 +78,6 @@ class FileControllerTest {
                 .andExpect(content().json(expectedJson))
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.url", matchesPattern("/api/files/[\\w]+")));
-    }
-
-    @Test
-    void downloadFile_whenNotLoggedIn_returnUnauthorized() throws Exception {
-        this.mvc.perform(get("/api/files/123"))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void downloadFile_whenLoggedInButUserDoesNotExistInDB_returnUnauthorized() throws Exception {
-        this.mvc.perform(get("/api/files/123")
-                        .with(oauth2Login())
-                )
-                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/file/controller/FileControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/file/controller/FileControllerTest.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class FileControllerTest {
 
     @Autowired
@@ -58,7 +59,6 @@ class FileControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void uploadFile_whenLoggedInButFileIsEmpty_returnBadRequest() throws Exception {
         // given
         User user = new User("123", "user", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -74,7 +74,6 @@ class FileControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void uploadFile_whenLoggedIn_returnFileMetadata() throws Exception {
         // given
         User user = new User("123", "user", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -117,7 +116,6 @@ class FileControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void downloadFile_whenLoggedInButFileDoesNotExist_returnNotFound() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -135,7 +133,6 @@ class FileControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void downloadFile_whenLoggedInButFileDoesNotBelongsToLoggedInUser_returnNotFound() throws Exception {
         // given
         User fileCreator = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -157,7 +154,6 @@ class FileControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void downloadFile_whenLoggedIn_returnFile() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class MixtapeControllerTest {
 
     @Autowired
@@ -52,7 +53,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void create_whenLoggedIn_thenReturnMixtape() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -96,7 +96,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void create_whenGivenJsonHasId_thenReturnUnprocessableEntity() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -124,7 +123,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void getAll_whenLoggedIn_thenReturnEmptyListIfNoMixtapesForTheLoggedInUserExist() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
@@ -142,7 +140,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void getAll_whenLoggedIn_thenReturnMixtapesForTheLoggedUser() throws Exception {
         // given
         String expectedJson = """
@@ -191,7 +188,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void delete_whenLoggedInButMixtapeDoesNotBelongToLoggedInUser_thenReturnNotFound() throws Exception {
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
@@ -206,7 +202,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void delete_whenLoggedInAndMixtapeBelongsToLoggedInUser_thenReturnOk() throws Exception {
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
@@ -221,7 +216,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void update_whenMixtapeDoesNotExist_thenReturnNotFound() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -252,7 +246,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void update_whenMixtapeDoesNotBelongToLoggedInUser_thenReturnNotFound() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -288,7 +281,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void update_whenLoggedInAndMixtapeExists_thenReturnOk() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -323,7 +315,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void get_whenLoggedInButMixtapeDoesNotExist_thenReturnNotFound() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
@@ -336,7 +327,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void get_whenLoggedInButMixtapeDoesNotBelongToLoggedInUser_thenReturnNotFound() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
@@ -353,7 +343,6 @@ class MixtapeControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void get_whenLoggedInAndMixtapeBelongsToLoggedInUser_thenReturnOk() throws Exception {
         // given
         String expectedJson = """

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class TrackControllerTest {
 
     @Autowired
@@ -51,7 +52,6 @@ class TrackControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void create_whenMixtapeDoesNotExist_thenReturnNotFound() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
@@ -76,7 +76,6 @@ class TrackControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void create_whenMixtapeDoesNotBelongToLoggedInUser_thenReturnNotFound() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
@@ -105,7 +104,6 @@ class TrackControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void create_whenMixtapeExistsAndBelongsToLoggedInUser_thenReturnOk() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -136,7 +134,6 @@ class TrackControllerTest {
     }
 
     @Test
-    @DirtiesContext
     void create_whenNumOfTracksExceedsMaxLimit_thenReturnBadRequest() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/user/controller/UserControllerTest.java
@@ -32,12 +32,6 @@ class UserControllerTest {
     private MockMvc mvc;
 
     @Test
-    void me_returnsUnauthorizedIfNotLoggedIn() throws Exception {
-        this.mvc.perform(get("/api/users/me"))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
     @DirtiesContext
     void me_returnsUserResourceIfLoggedIn() throws Exception {
         // given
@@ -57,12 +51,6 @@ class UserControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson, true));
-    }
-
-    @Test
-    void logout_returnsUnauthorizedIfNotLoggedIn() throws Exception {
-        this.mvc.perform(post("/api/users/logout"))
-                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/file/controller/FileControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/file/controller/FileControllerTest.java
@@ -1,0 +1,68 @@
+package com.github.chuettenrauch.mixifyapi.unit.file.controller;
+
+import com.github.chuettenrauch.mixifyapi.file.controller.FileController;
+import com.github.chuettenrauch.mixifyapi.file.service.FileService;
+import com.github.chuettenrauch.mixifyapi.security.config.SecurityConfig;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FileController.class)
+@ImportAutoConfiguration(classes = SecurityConfig.class)
+class FileControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private FileService fileService;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void uploadFile_whenNotLoggedIn_returnUnauthorized() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "image.jpg", "image/jpeg", "some image".getBytes());
+
+        this.mvc.perform(multipart("/api/files")
+                        .file(file)
+                )
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void uploadFile_whenLoggedInButUserDoesNotExistInDB_returnUnauthorized() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "file.txt", "text/plain", "some image".getBytes());
+
+        this.mvc.perform(multipart("/api/files")
+                        .file(file)
+                        .with(oauth2Login())
+                )
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void downloadFile_whenNotLoggedIn_returnUnauthorized() throws Exception {
+        this.mvc.perform(get("/api/files/123"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void downloadFile_whenLoggedInButUserDoesNotExistInDB_returnUnauthorized() throws Exception {
+        this.mvc.perform(get("/api/files/123")
+                        .with(oauth2Login())
+                )
+                .andExpect(status().isUnauthorized());
+    }
+
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/invite/model/InviteTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/invite/model/InviteTest.java
@@ -1,0 +1,39 @@
+package com.github.chuettenrauch.mixifyapi.unit.invite.model;
+
+import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class InviteTest {
+
+    @ParameterizedTest
+    @MethodSource("provideExpiredAtDates")
+    void isExpired(LocalDateTime expiredAt, boolean expected) {
+        // given
+        Invite sut = new Invite();
+        sut.setExpiredAt(expiredAt);
+
+        // when
+        boolean actual = sut.isExpired();
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    private static Stream<Arguments> provideExpiredAtDates() {
+        return Stream.of(
+                arguments(named("expired_at | now", LocalDateTime.now()), true),
+                arguments(named("expired_at | expired", LocalDateTime.now().minusSeconds(1)), true),
+                arguments(named("expired_at | not expired", LocalDateTime.now().plusSeconds(1)), false)
+        );
+    }
+
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/controller/InviteControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/controller/InviteControllerTest.java
@@ -55,6 +55,12 @@ class InviteControllerTest {
                 .andExpect(content().json(expectedJson, true));
     }
 
+    @Test
+    void acceptInvite_whenNotLoggedIn_thenReturnUnauthorized() throws Exception {
+        this.mvc.perform(put("/api/invites/123"))
+                .andExpect(status().isUnauthorized());
+    }
+
     private static Stream<Arguments> provideInvalidInviteJson() {
         return Stream.of(
                 arguments(named("mixtape | missing", """

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
@@ -271,7 +271,7 @@ class MixtapeServiceTest {
     }
 
     @Test
-    void getByIdForAuthenticatedUser_whenNotLoggedIn_thenThrowUnauthorizedException() {
+    void findByIdForAuthenticatedUser_whenNotLoggedIn_thenThrowUnauthorizedException() {
         // given
         UserService userService = mock(UserService.class);
         when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
@@ -289,7 +289,7 @@ class MixtapeServiceTest {
     }
 
     @Test
-    void getByIdForAuthenticatedUser_whenMixtapeNotFoundOrDoesNotBelongToUser_thenThrowNotFoundException() {
+    void findByIdForAuthenticatedUser_whenMixtapeNotFoundOrDoesNotBelongToUser_thenThrowNotFoundException() {
         // given
         String id = "123";
         User user = new User();
@@ -311,7 +311,7 @@ class MixtapeServiceTest {
     }
 
     @Test
-    void getByIdForAuthenticatedUser_whenLoggedInAndMixtapeBelongsToUser_thenReturnMixtape() {
+    void findByIdForAuthenticatedUser_whenLoggedInAndMixtapeBelongsToUser_thenReturnMixtape() {
         // given
         String id = "123";
         User user = new User();
@@ -332,6 +332,46 @@ class MixtapeServiceTest {
         // then
         assertEquals(expected, actual);
         verify(mixtapeRepository).findByIdAndCreatedBy(id, user);
+    }
+
+    @Test
+    void findById_whenMixtapeNotFound_thenThrowNotFoundException() {
+        // given
+        String id = "123";
+
+        MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
+        when(mixtapeRepository.findById(id)).thenReturn(Optional.empty());
+
+        UserService userService = mock(UserService.class);
+        Validator validator = mock(Validator.class);
+
+        // when
+        MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
+        assertThrows(NotFoundException.class, () -> sut.findById(id));
+
+        // then
+        verify(mixtapeRepository).findById(id);
+    }
+
+    @Test
+    void findById_whenMixtapeFound_thenReturnIt() {
+        // given
+        String id = "123";
+        Mixtape expected = new Mixtape();
+
+        MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
+        when(mixtapeRepository.findById(id)).thenReturn(Optional.of(expected));
+
+        UserService userService = mock(UserService.class);
+        Validator validator = mock(Validator.class);
+
+        // when
+        MixtapeService sut = new MixtapeService(mixtapeRepository, userService, validator);
+        Mixtape actual = sut.findById(id);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeRepository).findById(id);
     }
 
     @Test

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtapeUser/service/MixtapeUserServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtapeUser/service/MixtapeUserServiceTest.java
@@ -1,0 +1,99 @@
+package com.github.chuettenrauch.mixifyapi.unit.mixtapeUser.service;
+
+import com.github.chuettenrauch.mixifyapi.exception.NotFoundException;
+import com.github.chuettenrauch.mixifyapi.exception.UnauthorizedException;
+import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import com.github.chuettenrauch.mixifyapi.mixtapeUser.model.MixtapeUser;
+import com.github.chuettenrauch.mixifyapi.mixtapeUser.repository.MixtapeUserRepository;
+import com.github.chuettenrauch.mixifyapi.mixtapeUser.service.MixtapeUserService;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class MixtapeUserServiceTest {
+
+    @Test
+    void createFromInviteForAuthenticatedUser_whenNotLoggedIn_thenThrowUnauthorizedException() {
+        // given
+        Invite invite = new Invite();
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
+
+        assertThrows(UnauthorizedException.class, () -> sut.createFromInviteForAuthenticatedUser(invite));
+
+        // then
+        verify(mixtapeUserRepository, never()).save(any());
+    }
+
+    @Test
+    void createFromInviteForAuthenticatedUser_whenMixtapeDoesNotExist_thenThrowNotFoundException() {
+        // given
+        Invite invite = new Invite();
+        invite.setMixtape("123");
+
+        User user = new User();
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(invite.getMixtape())).thenThrow(NotFoundException.class);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
+
+        assertThrows(NotFoundException.class, () -> sut.createFromInviteForAuthenticatedUser(invite));
+
+        // then
+        verify(mixtapeUserRepository, never()).save(any());
+    }
+
+    @Test
+    void createFromInviteForAuthenticatedUser_whenLoggedInAndMixtapeNotExists_thenCreateMixtapeUser() {
+        // given
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId("123");
+
+        Invite invite = new Invite();
+        invite.setMixtape(mixtape.getId());
+
+        User user = new User();
+
+        MixtapeUser expected = new MixtapeUser(null, user, mixtape);
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+        when(mixtapeUserRepository.save(expected)).thenReturn(expected);
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(invite.getMixtape())).thenReturn(mixtape);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
+        MixtapeUser actual = sut.createFromInviteForAuthenticatedUser(invite);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeUserRepository).save(expected);
+    }
+
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/user/controller/UserControllerTest.java
@@ -1,0 +1,38 @@
+package com.github.chuettenrauch.mixifyapi.unit.user.controller;
+
+import com.github.chuettenrauch.mixifyapi.security.config.SecurityConfig;
+import com.github.chuettenrauch.mixifyapi.user.controller.UserController;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@ImportAutoConfiguration(classes = SecurityConfig.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void me_returnsUnauthorizedIfNotLoggedIn() throws Exception {
+        this.mvc.perform(get("/api/users/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void logout_returnsUnauthorizedIfNotLoggedIn() throws Exception {
+        this.mvc.perform(post("/api/users/logout"))
+                .andExpect(status().isUnauthorized());
+    }
+
+}


### PR DESCRIPTION
- `PUT /api/invites/{id}` to accept an invite for the logged in user
- if invite does not exist or is expired, then decline
- if invite is still valid, then create an entry in mixtapeUser collection to establish a connection between both