### PR TITLE
GH-110 - adjust GET /api/mixtapes to return all mixtapes, the user is connected to

### DIFF
--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -5,6 +5,8 @@ import com.github.chuettenrauch.mixifyapi.exception.UnprocessableEntityException
 import com.github.chuettenrauch.mixifyapi.exception.NotFoundException;
 import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
 import com.github.chuettenrauch.mixifyapi.mixtape.repository.MixtapeRepository;
+import com.github.chuettenrauch.mixifyapi.mixtape_user.model.MixtapeUser;
+import com.github.chuettenrauch.mixifyapi.mixtape_user.service.MixtapeUserService;
 import com.github.chuettenrauch.mixifyapi.user.model.User;
 import com.github.chuettenrauch.mixifyapi.user.service.UserService;
 import jakarta.validation.ConstraintViolation;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @Service
@@ -23,6 +26,8 @@ public class MixtapeService {
     private final MixtapeRepository mixtapeRepository;
 
     private final UserService userService;
+
+    private final MixtapeUserService mixtapeUserService;
 
     private final Validator validator;
 
@@ -37,7 +42,12 @@ public class MixtapeService {
     public List<Mixtape> findAllForAuthenticatedUser() {
         User user = this.userService.getAuthenticatedUser().orElseThrow(UnauthorizedException::new);
 
-        return this.mixtapeRepository.findAllByCreatedBy(user);
+        return this.mixtapeUserService
+                .findAllByUser(user)
+                .stream()
+                .map(MixtapeUser::getMixtape)
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     public Mixtape updateByIdForAuthenticatedUser(String id, Mixtape mixtape) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/repository/MixtapeUserRepository.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/repository/MixtapeUserRepository.java
@@ -6,10 +6,13 @@ import com.github.chuettenrauch.mixifyapi.user.model.User;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MixtapeUserRepository extends MongoRepository<MixtapeUser, String> {
 
     Optional<MixtapeUser> findByUserAndMixtape(User user, Mixtape mixtape);
+
+    List<MixtapeUser> findAllByUser(User user);
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
@@ -1,13 +1,9 @@
 package com.github.chuettenrauch.mixifyapi.mixtape_user.service;
 
-import com.github.chuettenrauch.mixifyapi.exception.UnauthorizedException;
-import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
 import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
-import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.model.MixtapeUser;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.repository.MixtapeUserRepository;
 import com.github.chuettenrauch.mixifyapi.user.model.User;
-import com.github.chuettenrauch.mixifyapi.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,17 +12,6 @@ import org.springframework.stereotype.Service;
 public class MixtapeUserService {
 
     private final MixtapeUserRepository mixtapeUserRepository;
-
-    private final MixtapeService mixtapeService;
-
-    private final UserService userService;
-
-    public MixtapeUser createFromInviteForAuthenticatedUserIfNotExists(Invite invite) {
-        User user = this.userService.getAuthenticatedUser().orElseThrow(UnauthorizedException::new);
-        Mixtape mixtape = this.mixtapeService.findById(invite.getMixtape());
-
-        return this.createIfNotExists(user, mixtape);
-    }
 
     public MixtapeUser createIfNotExists(User user, Mixtape mixtape) {
         MixtapeUser mixtapeUser = this.mixtapeUserRepository

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
@@ -7,11 +7,17 @@ import com.github.chuettenrauch.mixifyapi.user.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MixtapeUserService {
 
     private final MixtapeUserRepository mixtapeUserRepository;
+
+    public List<MixtapeUser> findAllByUser(User user) {
+        return this.mixtapeUserRepository.findAllByUser(user);
+    }
 
     public MixtapeUser createIfNotExists(User user, Mixtape mixtape) {
         MixtapeUser mixtapeUser = this.mixtapeUserRepository

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/invite/service/InviteServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/invite/service/InviteServiceTest.java
@@ -3,12 +3,17 @@ package com.github.chuettenrauch.mixifyapi.unit.invite.service;
 import com.github.chuettenrauch.mixifyapi.config.AppProperties;
 import com.github.chuettenrauch.mixifyapi.exception.GoneException;
 import com.github.chuettenrauch.mixifyapi.exception.NotFoundException;
+import com.github.chuettenrauch.mixifyapi.exception.UnauthorizedException;
 import com.github.chuettenrauch.mixifyapi.exception.UnprocessableEntityException;
 import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
 import com.github.chuettenrauch.mixifyapi.invite.repository.InviteRepository;
 import com.github.chuettenrauch.mixifyapi.invite.service.InviteService;
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.model.MixtapeUser;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.service.MixtapeUserService;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -30,6 +35,8 @@ class InviteServiceTest {
         InviteRepository inviteRepository = mock(InviteRepository.class);
         when(inviteRepository.save(given)).thenReturn(given);
 
+        UserService userService = mock(UserService.class);
+        MixtapeService mixtapeService = mock(MixtapeService.class);
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
 
         AppProperties.Invite inviteProperties = mock(AppProperties.Invite.class);
@@ -39,7 +46,13 @@ class InviteServiceTest {
         when(appProperties.getInvite()).thenReturn(inviteProperties);
 
         // when
-        InviteService sut = new InviteService(inviteRepository, mixtapeUserService, appProperties);
+        InviteService sut = new InviteService(
+                inviteRepository,
+                userService,
+                mixtapeService,
+                mixtapeUserService,
+                appProperties
+        );
 
         LocalDateTime beforeCreate = LocalDateTime.now();
         Invite actual = sut.save(given);
@@ -62,11 +75,20 @@ class InviteServiceTest {
         invite.setMixtape("abc123");
 
         InviteRepository inviteRepository = mock(InviteRepository.class);
+        UserService userService = mock(UserService.class);
+        MixtapeService mixtapeService = mock(MixtapeService.class);
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
         AppProperties appProperties = mock(AppProperties.class);
 
         // when
-        InviteService sut = new InviteService(inviteRepository, mixtapeUserService, appProperties);
+        InviteService sut = new InviteService(
+                inviteRepository,
+                userService,
+                mixtapeService,
+                mixtapeUserService,
+                appProperties
+        );
+
         assertThrows(UnprocessableEntityException.class, () -> sut.save(invite));
 
         // then
@@ -74,23 +96,64 @@ class InviteServiceTest {
     }
 
     @Test
-    void acceptInviteByIdForAuthenticatedUser_whenInviteDoesNotExist_thenThrowNotFoundException() {
+    void acceptInviteByIdForAuthenticatedUser_whenNotLoggedIn_thenThrowUnauthorizedException() {
         // given
         String id = "123";
 
         InviteRepository inviteRepository = mock(InviteRepository.class);
         when(inviteRepository.findById(id)).thenReturn(Optional.empty());
 
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
         AppProperties appProperties = mock(AppProperties.class);
 
         // when
-        InviteService sut = new InviteService(inviteRepository, mixtapeUserService, appProperties);
+        InviteService sut = new InviteService(
+                inviteRepository,
+                userService,
+                mixtapeService,
+                mixtapeUserService,
+                appProperties
+        );
+
+        assertThrows(UnauthorizedException.class, () -> sut.acceptInviteByIdForAuthenticatedUser(id));
+
+        // then
+        verify(mixtapeUserService, never()).createIfNotExists(any(), any());
+    }
+
+    @Test
+    void acceptInviteByIdForAuthenticatedUser_whenInviteDoesNotExist_thenThrowNotFoundException() {
+        // given
+        String id = "123";
+        User user = new User();
+
+        InviteRepository inviteRepository = mock(InviteRepository.class);
+        when(inviteRepository.findById(id)).thenReturn(Optional.empty());
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+        AppProperties appProperties = mock(AppProperties.class);
+
+        // when
+        InviteService sut = new InviteService(
+                inviteRepository,
+                userService,
+                mixtapeService,
+                mixtapeUserService,
+                appProperties
+        );
 
         assertThrows(NotFoundException.class, () -> sut.acceptInviteByIdForAuthenticatedUser(id));
 
         // then
-        verify(mixtapeUserService, never()).createFromInviteForAuthenticatedUserIfNotExists(any());
+        verify(mixtapeUserService, never()).createIfNotExists(any(), any());
     }
 
     @Test
@@ -98,22 +161,34 @@ class InviteServiceTest {
         // given
         String id = "123";
 
+        User user = new User();
+
         Invite invite = mock(Invite.class);
         when(invite.isExpired()).thenReturn(true);
 
         InviteRepository inviteRepository = mock(InviteRepository.class);
         when(inviteRepository.findById(id)).thenReturn(Optional.of(invite));
 
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
         AppProperties appProperties = mock(AppProperties.class);
 
         // when
-        InviteService sut = new InviteService(inviteRepository, mixtapeUserService, appProperties);
+        InviteService sut = new InviteService(
+                inviteRepository,
+                userService,
+                mixtapeService,
+                mixtapeUserService,
+                appProperties
+        );
 
         assertThrows(GoneException.class, () -> sut.acceptInviteByIdForAuthenticatedUser(id));
 
         // then
-        verify(mixtapeUserService, never()).createFromInviteForAuthenticatedUserIfNotExists(any());
+        verify(mixtapeUserService, never()).createIfNotExists(any(), any());
     }
 
     @Test
@@ -121,21 +196,37 @@ class InviteServiceTest {
         // given
         String id = "123";
 
+        User user = new User();
+
         Invite invite = mock(Invite.class);
         when(invite.isExpired()).thenReturn(true);
 
         InviteRepository inviteRepository = mock(InviteRepository.class);
         when(inviteRepository.findById(id)).thenReturn(Optional.of(invite));
 
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(id)).thenThrow(NotFoundException.class);
+
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
-        when(mixtapeUserService.createFromInviteForAuthenticatedUserIfNotExists(invite)).thenThrow(NotFoundException.class);
 
         AppProperties appProperties = mock(AppProperties.class);
 
         // when
-        InviteService sut = new InviteService(inviteRepository, mixtapeUserService, appProperties);
+        InviteService sut = new InviteService(
+                inviteRepository,
+                userService,
+                mixtapeService,
+                mixtapeUserService,
+                appProperties
+        );
 
         assertThrows(GoneException.class, () -> sut.acceptInviteByIdForAuthenticatedUser(id));
+
+        // then
+        verify(mixtapeUserService, never()).createIfNotExists(any(), any());
     }
 
     @Test
@@ -143,26 +234,44 @@ class InviteServiceTest {
         // given
         String id = "123";
 
+        User user = new User();
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId("mixtape-123");
+
         Invite invite = mock(Invite.class);
         when(invite.isExpired()).thenReturn(false);
+        when(invite.getMixtape()).thenReturn(mixtape.getId());
 
         MixtapeUser expected = new MixtapeUser();
 
         InviteRepository inviteRepository = mock(InviteRepository.class);
         when(inviteRepository.findById(id)).thenReturn(Optional.of(invite));
 
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.findById(mixtape.getId())).thenReturn(mixtape);
+
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
-        when(mixtapeUserService.createFromInviteForAuthenticatedUserIfNotExists(invite)).thenReturn(expected);
+        when(mixtapeUserService.createIfNotExists(user, mixtape)).thenReturn(expected);
 
         AppProperties appProperties = mock(AppProperties.class);
 
         // when
-        InviteService sut = new InviteService(inviteRepository, mixtapeUserService, appProperties);
+        InviteService sut = new InviteService(
+                inviteRepository,
+                userService,
+                mixtapeService,
+                mixtapeUserService,
+                appProperties
+        );
+
         MixtapeUser actual = sut.acceptInviteByIdForAuthenticatedUser(id);
 
         // then
         assertEquals(expected, actual);
-        verify(mixtapeUserService).createFromInviteForAuthenticatedUserIfNotExists(invite);
+        verify(mixtapeUserService).createIfNotExists(user, mixtape);
     }
 
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
@@ -1,133 +1,18 @@
 package com.github.chuettenrauch.mixifyapi.unit.mixtape_user.service;
 
-import com.github.chuettenrauch.mixifyapi.exception.NotFoundException;
-import com.github.chuettenrauch.mixifyapi.exception.UnauthorizedException;
-import com.github.chuettenrauch.mixifyapi.invite.model.Invite;
 import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
-import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.model.MixtapeUser;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.repository.MixtapeUserRepository;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.service.MixtapeUserService;
 import com.github.chuettenrauch.mixifyapi.user.model.User;
-import com.github.chuettenrauch.mixifyapi.user.service.UserService;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 class MixtapeUserServiceTest {
-
-    @Test
-    void createFromInviteForAuthenticatedUserIfNotExists_whenNotLoggedIn_thenThrowUnauthorizedException() {
-        // given
-        Invite invite = new Invite();
-
-        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
-        MixtapeService mixtapeService = mock(MixtapeService.class);
-
-        UserService userService = mock(UserService.class);
-        when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
-
-        // when
-        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
-
-        assertThrows(UnauthorizedException.class, () -> sut.createFromInviteForAuthenticatedUserIfNotExists(invite));
-
-        // then
-        verify(mixtapeUserRepository, never()).save(any());
-    }
-
-    @Test
-    void createFromInviteForAuthenticatedUserIfNotExists_whenMixtapeDoesNotExist_thenThrowNotFoundException() {
-        // given
-        Invite invite = new Invite();
-        invite.setMixtape("123");
-
-        User user = new User();
-
-        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
-
-        MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(invite.getMixtape())).thenThrow(NotFoundException.class);
-
-        UserService userService = mock(UserService.class);
-        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
-
-        // when
-        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
-
-        assertThrows(NotFoundException.class, () -> sut.createFromInviteForAuthenticatedUserIfNotExists(invite));
-
-        // then
-        verify(mixtapeUserRepository, never()).save(any());
-    }
-
-    @Test
-    void createFromInviteForAuthenticatedUserIfNotExists_whenLoggedInAndMixtapeExists_thenCreateMixtapeUser() {
-        // given
-        Mixtape mixtape = new Mixtape();
-        mixtape.setId("123");
-
-        Invite invite = new Invite();
-        invite.setMixtape(mixtape.getId());
-
-        User user = new User();
-
-        MixtapeUser expected = new MixtapeUser(null, user, mixtape);
-
-        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
-        when(mixtapeUserRepository.findByUserAndMixtape(user, mixtape)).thenReturn(Optional.empty());
-        when(mixtapeUserRepository.save(expected)).thenReturn(expected);
-
-        MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(invite.getMixtape())).thenReturn(mixtape);
-
-        UserService userService = mock(UserService.class);
-        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
-
-        // when
-        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
-        MixtapeUser actual = sut.createFromInviteForAuthenticatedUserIfNotExists(invite);
-
-        // then
-        assertEquals(expected, actual);
-        verify(mixtapeUserRepository).save(expected);
-    }
-
-    @Test
-    void createFromInviteForAuthenticatedUserIfNotExists_whenMixtapeUserAlreadyExists_thenReturnMixtapeUser() {
-        // given
-        Mixtape mixtape = new Mixtape();
-        mixtape.setId("123");
-
-        Invite invite = new Invite();
-        invite.setMixtape(mixtape.getId());
-
-        User user = new User();
-
-        MixtapeUser expected = new MixtapeUser(null, user, mixtape);
-
-        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
-        when(mixtapeUserRepository.findByUserAndMixtape(user, mixtape)).thenReturn(Optional.of(expected));
-        when(mixtapeUserRepository.save(expected)).thenReturn(expected);
-
-        MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.findById(invite.getMixtape())).thenReturn(mixtape);
-
-        UserService userService = mock(UserService.class);
-        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
-
-        // when
-        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
-        MixtapeUser actual = sut.createFromInviteForAuthenticatedUserIfNotExists(invite);
-
-        // then
-        assertEquals(expected, actual);
-        verify(mixtapeUserRepository).save(expected);
-    }
 
     @Test
     void createIfNotExists_whenMixtapeUserNotExists_thenCreateAndReturn() {
@@ -140,11 +25,8 @@ class MixtapeUserServiceTest {
         when(mixtapeUserRepository.findByUserAndMixtape(user, mixtape)).thenReturn(Optional.empty());
         when(mixtapeUserRepository.save(expected)).thenReturn(expected);
 
-        MixtapeService mixtapeService = mock(MixtapeService.class);
-        UserService userService = mock(UserService.class);
-
         // when
-        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository);
         MixtapeUser actual = sut.createIfNotExists(user, mixtape);
 
         // then
@@ -163,11 +45,8 @@ class MixtapeUserServiceTest {
         when(mixtapeUserRepository.findByUserAndMixtape(user, mixtape)).thenReturn(Optional.of(expected));
         when(mixtapeUserRepository.save(expected)).thenReturn(expected);
 
-        MixtapeService mixtapeService = mock(MixtapeService.class);
-        UserService userService = mock(UserService.class);
-
         // when
-        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository, mixtapeService, userService);
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository);
         MixtapeUser actual = sut.createIfNotExists(user, mixtape);
 
         // then

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
@@ -7,12 +7,35 @@ import com.github.chuettenrauch.mixifyapi.mixtape_user.service.MixtapeUserServic
 import com.github.chuettenrauch.mixifyapi.user.model.User;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class MixtapeUserServiceTest {
+
+    @Test
+    void findAllForUser_whenCalled_thenDelegateToMixtapeUserRepository() {
+        // given
+        User user = new User();
+
+        List<MixtapeUser> expected = List.of(
+                new MixtapeUser(),
+                new MixtapeUser()
+        );
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+        when(mixtapeUserRepository.findAllByUser(user)).thenReturn(expected);
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository);
+        List<MixtapeUser> actual = sut.findAllByUser(user);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeUserRepository).findAllByUser(user);
+    }
 
     @Test
     void createIfNotExists_whenMixtapeUserNotExists_thenCreateAndReturn() {


### PR DESCRIPTION
- moved creation of MixtapeUser from invite to InviteService to avoid circular references between MixtapeService and MixtapeUserService
- adjusted findAllForAuthenticatedUser method in MixtapeService to return not only the mixtapes the user is creator of, but also mixtapes, that are shared with them