### PR TITLE
GH-113 - allow GET mixtape endpoint also for listeners

### DIFF
--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
@@ -5,6 +5,7 @@ import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,16 +29,19 @@ public class MixtapeController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("@mixtapePermissionService.canView(#id)")
     public Mixtape get(@PathVariable String id) {
         return this.mixtapeService.findByIdForAuthenticatedUser(id);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("@mixtapePermissionService.canEdit(#id)")
     public Mixtape update(@PathVariable String id, @Valid @RequestBody Mixtape mixtape) {
         return this.mixtapeService.updateByIdForAuthenticatedUser(id, mixtape);
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("@mixtapePermissionService.canEdit(#id)")
     public void delete(@PathVariable String id) {
         this.mixtapeService.deleteByIdForAuthenticatedUser(id);
     }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/TrackController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/TrackController.java
@@ -4,6 +4,7 @@ import com.github.chuettenrauch.mixifyapi.mixtape.model.Track;
 import com.github.chuettenrauch.mixifyapi.mixtape.service.TrackService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,16 +15,19 @@ public class TrackController {
     private final TrackService trackService;
 
     @PostMapping
+    @PreAuthorize("@mixtapePermissionService.canEdit(#mixtapeId)")
     public Track create(@PathVariable String mixtapeId, @Valid @RequestBody Track track) {
         return this.trackService.saveForMixtape(mixtapeId, track);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("@mixtapePermissionService.canEdit(#mixtapeId)")
     public Track update(@Valid @PathVariable String mixtapeId, @PathVariable String id, @Valid @RequestBody Track track) {
         return this.trackService.updateByIdForMixtape(mixtapeId, id, track);
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("@mixtapePermissionService.canEdit(#mixtapeId)")
     public void delete(@PathVariable String mixtapeId, @PathVariable String id) {
         this.trackService.deleteByIdForMixtape(mixtapeId, id);
     }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/security/MixtapePermissionService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/security/MixtapePermissionService.java
@@ -1,0 +1,36 @@
+package com.github.chuettenrauch.mixifyapi.mixtape.security;
+
+import com.github.chuettenrauch.mixifyapi.exception.UnauthorizedException;
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import com.github.chuettenrauch.mixifyapi.mixtape_user.service.MixtapeUserService;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MixtapePermissionService {
+
+    private final MixtapeService mixtapeService;
+
+    private final MixtapeUserService mixtapeUserService;
+
+    private final UserService userService;
+
+    public boolean canView(String mixtapeId) {
+        User user = this.userService.getAuthenticatedUser().orElseThrow(UnauthorizedException::new);
+
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId(mixtapeId);
+
+        return this.mixtapeUserService.existsByUserAndMixtape(user, mixtape);
+    }
+
+    public boolean canEdit(String mixtapeId) {
+        User user = this.userService.getAuthenticatedUser().orElseThrow(UnauthorizedException::new);
+
+        return this.mixtapeService.existsByIdAndCreatedBy(mixtapeId, user);
+    }
+}

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -80,8 +80,12 @@ public class MixtapeService {
         User user = this.userService.getAuthenticatedUser()
                 .orElseThrow(UnauthorizedException::new);
 
-        return this.mixtapeRepository.findByIdAndCreatedBy(id, user)
-                .orElseThrow(NotFoundException::new);
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId(id);
+
+        return this.mixtapeUserService
+                .findByUserAndMixtape(user, mixtape)
+                .getMixtape();
     }
 
     public Mixtape findById(String id) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -93,6 +93,10 @@ public class MixtapeService {
         return this.mixtapeRepository.existsById(id);
     }
 
+    public boolean existsByIdAndCreatedBy(String id, User createdBy) {
+        return this.mixtapeRepository.existsByIdAndCreatedBy(id, createdBy);
+    }
+
     private void validateTracks(Mixtape mixtape) {
         Set<ConstraintViolation<Mixtape>> errors = validator.validateProperty(mixtape, "tracks");
         if (!errors.isEmpty()) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/repository/MixtapeUserRepository.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/repository/MixtapeUserRepository.java
@@ -15,4 +15,6 @@ public interface MixtapeUserRepository extends MongoRepository<MixtapeUser, Stri
     Optional<MixtapeUser> findByUserAndMixtape(User user, Mixtape mixtape);
 
     List<MixtapeUser> findAllByUser(User user);
+
+    boolean existsByUserAndMixtape(User user, Mixtape mixtape);
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
@@ -1,5 +1,6 @@
 package com.github.chuettenrauch.mixifyapi.mixtape_user.service;
 
+import com.github.chuettenrauch.mixifyapi.exception.NotFoundException;
 import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.model.MixtapeUser;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.repository.MixtapeUserRepository;
@@ -17,6 +18,12 @@ public class MixtapeUserService {
 
     public List<MixtapeUser> findAllByUser(User user) {
         return this.mixtapeUserRepository.findAllByUser(user);
+    }
+
+    public MixtapeUser findByUserAndMixtape(User user, Mixtape mixtape) {
+        return this.mixtapeUserRepository
+                .findByUserAndMixtape(user, mixtape)
+                .orElseThrow(NotFoundException::new);
     }
 
     public MixtapeUser createIfNotExists(User user, Mixtape mixtape) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
@@ -26,4 +26,8 @@ public class MixtapeUserService {
 
         return this.mixtapeUserRepository.save(mixtapeUser);
     }
+
+    public boolean existsByUserAndMixtape(User user, Mixtape mixtape) {
+        return this.mixtapeUserRepository.existsByUserAndMixtape(user, mixtape);
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
@@ -19,6 +20,7 @@ import org.springframework.security.web.authentication.*;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final AppProperties appProperties;

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/model/UserResource.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/model/UserResource.java
@@ -11,4 +11,8 @@ public class UserResource {
     private String imageUrl;
     @NonNull private String providerAccessToken;
     private String providerRefreshToken;
+
+    public UserResource(String name, String imageUrl, String providerAccessToken) {
+        this(name, imageUrl, providerAccessToken, null);
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/model/UserResource.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/user/model/UserResource.java
@@ -8,7 +8,7 @@ import lombok.*;
 @RequiredArgsConstructor
 public class UserResource {
     @NonNull private String name;
-    @NonNull private String imageUrl;
+    private String imageUrl;
     @NonNull private String providerAccessToken;
     private String providerRefreshToken;
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -183,7 +183,7 @@ class MixtapeControllerTest {
     }
 
     @Test
-    void delete_whenLoggedInButCanNotEdit_thenReturnForbidden() throws Exception {
+    void delete_whenLoggedInButCanNotEditBecauseIsMixtapeOfOtherUser_thenReturnForbidden() throws Exception {
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
 
@@ -232,7 +232,7 @@ class MixtapeControllerTest {
     }
 
     @Test
-    void update_whenLoggedInButCanNotEdit_thenReturnForbidden() throws Exception {
+    void update_whenLoggedInButCanNotEditBecauseIsMixtapeOfOtherUser_thenReturnForbidden() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
@@ -339,7 +339,7 @@ class MixtapeControllerTest {
     }
 
     @Test
-    void get_whenLoggedInButCanNotView_thenReturnForbidden() throws Exception {
+    void get_whenLoggedInButCanNotViewBecauseIsMixtapeOfOtherUser_thenReturnForbidden() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
@@ -57,7 +57,7 @@ class TrackControllerTest {
     }
 
     @Test
-    void create_whenLoggedInButCanNotEdit_thenReturnForbidden() throws Exception {
+    void create_whenLoggedInButCanNotEditBecauseIsMixtapeOfOtherUser_thenReturnForbidden() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
@@ -185,7 +185,7 @@ class TrackControllerTest {
     }
 
     @Test
-    void update_whenLoggedInButCanNotEdit_thenReturnForbidden() throws Exception {
+    void update_whenLoggedInButCanNotEditBecauseIsMixtapeOfOtherUser_thenReturnForbidden() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
@@ -319,7 +319,7 @@ class TrackControllerTest {
     }
 
     @Test
-    void delete_whenLoggedInButCanNotEdit_thenReturnForbidden() throws Exception {
+    void delete_whenLoggedInButCanNotEditBecauseIsMixtapeOfOtherUser_thenReturnForbidden() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
@@ -52,31 +52,7 @@ class TrackControllerTest {
     }
 
     @Test
-    void create_whenMixtapeDoesNotExist_thenReturnNotFound() throws Exception {
-        // given
-        OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
-
-        String givenJson = """
-                {
-                    "name": "The Chipmunks Song",
-                    "artist": "Alvin & The Chipmunks",
-                    "imageUrl": "http://path/to/image",
-                    "description": null,
-                    "providerUri": "spotify:track:12345"
-                }
-                """;
-
-        // when + then
-        this.mvc.perform(post("/api/mixtapes/123/tracks")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(givenJson)
-                        .with(oauth2Login().oauth2User(oAuth2User))
-                )
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void create_whenMixtapeDoesNotBelongToLoggedInUser_thenReturnNotFound() throws Exception {
+    void create_whenLoggedInButCanNotEdit_thenReturnForbidden() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
@@ -100,11 +76,11 @@ class TrackControllerTest {
                         .content(givenJson)
                         .with(oauth2Login().oauth2User(oAuth2User))
                 )
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test
-    void create_whenMixtapeExistsAndBelongsToLoggedInUser_thenReturnOk() throws Exception {
+    void create_whenLoggedInAndCanEdit_thenReturnOk() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
@@ -171,32 +147,7 @@ class TrackControllerTest {
     }
 
     @Test
-    void update_whenMixtapeNotFound_thenReturnNotFound() throws Exception {
-        // given
-        OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
-
-        String givenJson = """
-                {
-                    "id": "234",
-                    "name": "The Chipmunks Song",
-                    "artist": "Alvin & The Chipmunks",
-                    "imageUrl": "http://path/to/image",
-                    "description": null,
-                    "providerUri": "spotify:track:12345"
-                }
-                """;
-
-        // when + then
-        this.mvc.perform(put("/api/mixtapes/123/tracks/234")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(givenJson)
-                        .with(oauth2Login().oauth2User(oAuth2User))
-                )
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void update_whenMixtapeDoesNotBelongToLoggedInUser_thenReturnNotFound() throws Exception {
+    void update_whenLoggedInButCanNotEdit_thenReturnForbidden() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
@@ -224,7 +175,7 @@ class TrackControllerTest {
                         .content(givenJson)
                         .with(oauth2Login().oauth2User(oAuth2User))
                 )
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -260,7 +211,7 @@ class TrackControllerTest {
     }
 
     @Test
-    void update_whenTrackExists_thenReturnOk() throws Exception {
+    void update_whenLoggedInAndCanEdit_thenReturnOk() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
@@ -293,18 +244,7 @@ class TrackControllerTest {
     }
 
     @Test
-    void delete_whenMixtapeNotFound_thenReturnNotFound() throws Exception {
-        // given
-        OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
-        // when + then
-        this.mvc.perform(delete("/api/mixtapes/123/tracks/234")
-                        .with(oauth2Login().oauth2User(oAuth2User))
-                )
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void delete_whenMixtapeDoesNotBelongToLoggedInUser_thenReturnNotFound() throws Exception {
+    void delete_whenLoggedInButCanNotEdit_thenReturnForbidden() throws Exception {
         // given
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
@@ -319,7 +259,7 @@ class TrackControllerTest {
         this.mvc.perform(delete("/api/mixtapes/123/tracks/234")
                         .with(oauth2Login().oauth2User(oAuth2User))
                 )
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -342,7 +282,7 @@ class TrackControllerTest {
     }
 
     @Test
-    void delete_whenTrackExists_thenReturnOk() throws Exception {
+    void delete_whenLoggedInAndCanEdit_thenReturnOk() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/security/MixtapePermissionServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/security/MixtapePermissionServiceTest.java
@@ -1,0 +1,143 @@
+package com.github.chuettenrauch.mixifyapi.unit.mixtape.security;
+
+import com.github.chuettenrauch.mixifyapi.exception.UnauthorizedException;
+import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
+import com.github.chuettenrauch.mixifyapi.mixtape.security.MixtapePermissionService;
+import com.github.chuettenrauch.mixifyapi.mixtape.service.MixtapeService;
+import com.github.chuettenrauch.mixifyapi.mixtape_user.service.MixtapeUserService;
+import com.github.chuettenrauch.mixifyapi.user.model.User;
+import com.github.chuettenrauch.mixifyapi.user.service.UserService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MixtapePermissionServiceTest {
+
+    @Test
+    void canView_whenNotLoggedIn_thenThrowUnauthorizedException() {
+        // given
+        String mixtapeId = "123";
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
+
+        // when + then
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+
+        assertThrows(UnauthorizedException.class, () -> sut.canView(mixtapeId));
+    }
+
+    @Test
+    void canView_whenMixtapeUserEntryExistsForUserAndMixtape_thenReturnTrue() {
+        // given
+        User user = new User();
+
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId("123");
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+        when(mixtapeUserService.existsByUserAndMixtape(user, mixtape)).thenReturn(true);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+        boolean actual = sut.canView(mixtape.getId());
+
+        // then
+        assertTrue(actual);
+    }
+
+    @Test
+    void canView_whenMixtapeUserEntryDoesNotExistForUserAndMixtape_thenReturnFalse() {
+        // given
+        User user = new User();
+
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId("123");
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+        when(mixtapeUserService.existsByUserAndMixtape(user, mixtape)).thenReturn(false);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+        boolean actual = sut.canView(mixtape.getId());
+
+        // then
+        assertFalse(actual);
+    }
+
+    @Test
+    void canEdit_whenNotLoggedIn_thenThrowUnauthorizedException() {
+        // given
+        String mixtapeId = "123";
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
+
+        // when + then
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+
+        assertThrows(UnauthorizedException.class, () -> sut.canEdit(mixtapeId));
+    }
+
+    @Test
+    void canEdit_whenUserIsCreatorOfMixtape_thenReturnTrue() {
+        // given
+        String mixtapeId = "123";
+        User user = new User();
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.existsByIdAndCreatedBy(mixtapeId, user)).thenReturn(true);
+
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+        boolean actual = sut.canEdit(mixtapeId);
+
+        // then
+        assertTrue(actual);
+    }
+
+    @Test
+    void canView_whenUserIsNotCreatorOfMixtape_thenReturnFalse() {
+        // given
+        String mixtapeId = "123";
+        User user = new User();
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        when(mixtapeService.existsByIdAndCreatedBy(mixtapeId, user)).thenReturn(false);
+
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+        boolean actual = sut.canEdit(mixtapeId);
+
+        // then
+        assertFalse(actual);
+    }
+}

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
@@ -319,42 +319,51 @@ class MixtapeServiceTest {
     }
 
     @Test
-    void findByIdForAuthenticatedUser_whenMixtapeNotFoundOrDoesNotBelongToUser_thenThrowNotFoundException() {
+    void findByIdForAuthenticatedUser_whenLoggedInUserIsNotListener_thenThrowNotFoundException() {
         // given
-        String id = "123";
+        String mixtapeId = "123";
         User user = new User();
+
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId(mixtapeId);
 
         UserService userService = mock(UserService.class);
         when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
 
         MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
-        when(mixtapeRepository.findByIdAndCreatedBy(id, user)).thenReturn(Optional.empty());
 
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+        when(mixtapeUserService.findByUserAndMixtape(user, mixtape)).thenThrow(NotFoundException.class);
+
         Validator validator = mock(Validator.class);
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, mixtapeUserService, validator);
-        assertThrows(NotFoundException.class, () -> sut.findByIdForAuthenticatedUser(id));
+        assertThrows(NotFoundException.class, () -> sut.findByIdForAuthenticatedUser(mixtapeId));
 
         // then
-        verify(mixtapeRepository).findByIdAndCreatedBy(id, user);
+        verify(mixtapeUserService).findByUserAndMixtape(user, mixtape);
     }
 
     @Test
-    void findByIdForAuthenticatedUser_whenLoggedInAndMixtapeBelongsToUser_thenReturnMixtape() {
+    void findByIdForAuthenticatedUser_whenLoggedInAndUserIsListener_thenReturnMixtape() {
         // given
         String id = "123";
         User user = new User();
+
         Mixtape expected = new Mixtape();
+        expected.setId("123");
+
+        MixtapeUser mixtapeUser = new MixtapeUser(null, user, expected);
 
         UserService userService = mock(UserService.class);
         when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
 
         MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
-        when(mixtapeRepository.findByIdAndCreatedBy(id, user)).thenReturn(Optional.of(expected));
 
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+        when(mixtapeUserService.findByUserAndMixtape(user, expected)).thenReturn(mixtapeUser);
+
         Validator validator = mock(Validator.class);
 
         // when
@@ -363,27 +372,7 @@ class MixtapeServiceTest {
 
         // then
         assertEquals(expected, actual);
-        verify(mixtapeRepository).findByIdAndCreatedBy(id, user);
-    }
-
-    @Test
-    void findById_whenMixtapeNotFound_thenThrowNotFoundException() {
-        // given
-        String id = "123";
-
-        MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
-        when(mixtapeRepository.findById(id)).thenReturn(Optional.empty());
-
-        UserService userService = mock(UserService.class);
-        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
-        Validator validator = mock(Validator.class);
-
-        // when
-        MixtapeService sut = new MixtapeService(mixtapeRepository, userService, mixtapeUserService, validator);
-        assertThrows(NotFoundException.class, () -> sut.findById(id));
-
-        // then
-        verify(mixtapeRepository).findById(id);
+        verify(mixtapeUserService).findByUserAndMixtape(user, expected);
     }
 
     @Test

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
@@ -431,6 +431,31 @@ class MixtapeServiceTest {
         verify(mixtapeRepository).existsById(id);
     }
 
+    @Test
+    void existsByIdAndCreatedBy_whenCalled_thenDelegatesToMixtapeRepository() {
+        // given
+        String id = "123";
+        User user = new User();
+
+        boolean expected = true;
+
+        UserService userService = mock(UserService.class);
+
+        MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
+        when(mixtapeRepository.existsByIdAndCreatedBy(id, user)).thenReturn(expected);
+
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+        Validator validator = mock(Validator.class);
+
+        // when
+        MixtapeService sut = new MixtapeService(mixtapeRepository, userService, mixtapeUserService, validator);
+        boolean actual = sut.existsByIdAndCreatedBy(id, user);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeRepository).existsByIdAndCreatedBy(id, user);
+    }
+
     /**
      * This is only to overcome the issue, that it is not possible to mock classes with generic parameters
      */

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
@@ -77,4 +77,23 @@ class MixtapeUserServiceTest {
         verify(mixtapeUserRepository).save(expected);
     }
 
+    @Test
+    void existsByUserAndMixtape_whenCalled_thenDelegateToMixtapeUserRepository() {
+        // given
+        User user = new User();
+        Mixtape mixtape = new Mixtape();
+        boolean expected = true;
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+        when(mixtapeUserRepository.existsByUserAndMixtape(user, mixtape)).thenReturn(expected);
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository);
+        boolean actual = sut.existsByUserAndMixtape(user, mixtape);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeUserRepository).existsByUserAndMixtape(user, mixtape);
+    }
+
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
@@ -1,5 +1,6 @@
 package com.github.chuettenrauch.mixifyapi.unit.mixtape_user.service;
 
+import com.github.chuettenrauch.mixifyapi.exception.NotFoundException;
 import com.github.chuettenrauch.mixifyapi.mixtape.model.Mixtape;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.model.MixtapeUser;
 import com.github.chuettenrauch.mixifyapi.mixtape_user.repository.MixtapeUserRepository;
@@ -35,6 +36,41 @@ class MixtapeUserServiceTest {
         // then
         assertEquals(expected, actual);
         verify(mixtapeUserRepository).findAllByUser(user);
+    }
+
+    @Test
+    void findByUserAndMixtape_whenFound_thenReturn() {
+        // given
+        User user = new User();
+        Mixtape mixtape = new Mixtape();
+
+        MixtapeUser expected = new MixtapeUser(null, user, mixtape);
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+        when(mixtapeUserRepository.findByUserAndMixtape(user, mixtape)).thenReturn(Optional.of(expected));
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository);
+        MixtapeUser actual = sut.findByUserAndMixtape(user, mixtape);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeUserRepository).findByUserAndMixtape(user, mixtape);
+    }
+
+    @Test
+    void findByUserAndMixtape_whenNotFound_thenThrowNotFoundException() {
+        // given
+        User user = new User();
+        Mixtape mixtape = new Mixtape();
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+        when(mixtapeUserRepository.findByUserAndMixtape(user, mixtape)).thenReturn(Optional.empty());
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository);
+
+        assertThrows(NotFoundException.class, () -> sut.findByUserAndMixtape(user, mixtape));
     }
 
     @Test


### PR DESCRIPTION
- allow GET mixtape endpoint also for listeners, not only for creator of the mixtape
- DELETE, PUT and all track endpoints are still only available for the mixtape creator
- fixed small login bug, when spotify user has no image set