### PR TITLE
GH-125 - added draft mode for mixtapes

### DIFF
--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/controller/MixtapeController.java
@@ -41,7 +41,7 @@ public class MixtapeController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("@mixtapePermissionService.canEdit(#id)")
+    @PreAuthorize("@mixtapePermissionService.canDelete(#id)")
     public void delete(@PathVariable String id) {
         this.mixtapeService.deleteByIdForAuthenticatedUser(id);
     }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
@@ -43,7 +43,7 @@ public class Mixtape {
     @DocumentReference(lazy = true)
     private User createdBy;
 
-    private boolean draft;
+    private boolean draft = true;
 
     public boolean hasTrackWithId(String id) {
         return this.getTracks()

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/model/Mixtape.java
@@ -43,6 +43,8 @@ public class Mixtape {
     @DocumentReference(lazy = true)
     private User createdBy;
 
+    private boolean draft;
+
     public boolean hasTrackWithId(String id) {
         return this.getTracks()
                 .stream()

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/repository/MixtapeRepository.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/repository/MixtapeRepository.java
@@ -5,14 +5,8 @@ import com.github.chuettenrauch.mixifyapi.user.model.User;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface MixtapeRepository extends MongoRepository<Mixtape, String> {
-    List<Mixtape> findAllByCreatedBy(User createdBy);
 
-    Optional<Mixtape> findByIdAndCreatedBy(String id, User createdBy);
-
-    boolean existsByIdAndCreatedBy(String id, User createdBy);
+    boolean existsByIdAndCreatedByAndDraftTrue(String id, User createdBy);
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/security/MixtapePermissionService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/security/MixtapePermissionService.java
@@ -33,4 +33,8 @@ public class MixtapePermissionService {
 
         return this.mixtapeService.existsByIdAndCreatedByAndDraftTrue(mixtapeId, user);
     }
+
+    public boolean canDelete(String mixtapeId) {
+        return this.canView(mixtapeId);
+    }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/security/MixtapePermissionService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/security/MixtapePermissionService.java
@@ -31,6 +31,6 @@ public class MixtapePermissionService {
     public boolean canEdit(String mixtapeId) {
         User user = this.userService.getAuthenticatedUser().orElseThrow(UnauthorizedException::new);
 
-        return this.mixtapeService.existsByIdAndCreatedBy(mixtapeId, user);
+        return this.mixtapeService.existsByIdAndCreatedByAndDraftTrue(mixtapeId, user);
     }
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -69,11 +69,18 @@ public class MixtapeService {
         User user = this.userService.getAuthenticatedUser()
                 .orElseThrow(UnauthorizedException::new);
 
-        if (!this.mixtapeRepository.existsByIdAndCreatedBy(id, user)) {
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId(id);
+
+        if (!this.mixtapeUserService.existsByUserAndMixtape(user, mixtape)) {
             throw new NotFoundException();
         }
 
-        this.mixtapeRepository.deleteById(id);
+        this.mixtapeUserService.deleteByUserAndMixtape(user, mixtape);
+
+        if (!this.mixtapeUserService.existsByMixtape(mixtape)) {
+            this.mixtapeRepository.deleteById(id);
+        }
     }
 
     public Mixtape findByIdForAuthenticatedUser(String id) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape/service/MixtapeService.java
@@ -54,7 +54,7 @@ public class MixtapeService {
         User user = this.userService.getAuthenticatedUser()
                 .orElseThrow(UnauthorizedException::new);
 
-        if (!this.mixtapeRepository.existsByIdAndCreatedBy(id, user)) {
+        if (!this.existsByIdAndCreatedByAndDraftTrue(id, user)) {
             throw new NotFoundException();
         }
 
@@ -104,8 +104,8 @@ public class MixtapeService {
         return this.mixtapeRepository.existsById(id);
     }
 
-    public boolean existsByIdAndCreatedBy(String id, User createdBy) {
-        return this.mixtapeRepository.existsByIdAndCreatedBy(id, createdBy);
+    public boolean existsByIdAndCreatedByAndDraftTrue(String id, User createdBy) {
+        return this.mixtapeRepository.existsByIdAndCreatedByAndDraftTrue(id, createdBy);
     }
 
     private void validateTracks(Mixtape mixtape) {

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/repository/MixtapeUserRepository.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/repository/MixtapeUserRepository.java
@@ -17,4 +17,8 @@ public interface MixtapeUserRepository extends MongoRepository<MixtapeUser, Stri
     List<MixtapeUser> findAllByUser(User user);
 
     boolean existsByUserAndMixtape(User user, Mixtape mixtape);
+
+    boolean existsByMixtape(Mixtape mixtape);
+
+    void deleteByUserAndMixtape(User user, Mixtape mixtape);
 }

--- a/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
+++ b/backend/src/main/java/com/github/chuettenrauch/mixifyapi/mixtape_user/service/MixtapeUserService.java
@@ -37,4 +37,12 @@ public class MixtapeUserService {
     public boolean existsByUserAndMixtape(User user, Mixtape mixtape) {
         return this.mixtapeUserRepository.existsByUserAndMixtape(user, mixtape);
     }
+
+    public boolean existsByMixtape(Mixtape mixtape) {
+        return this.mixtapeUserRepository.existsByMixtape(mixtape);
+    }
+
+    public void deleteByUserAndMixtape(User user, Mixtape mixtape) {
+        this.mixtapeUserRepository.deleteByUserAndMixtape(user, mixtape);
+    }
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/invite/controller/InviteControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/invite/controller/InviteControllerTest.java
@@ -57,7 +57,7 @@ class InviteControllerTest {
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         String givenJson = """
@@ -85,7 +85,7 @@ class InviteControllerTest {
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         String givenJson = """
@@ -123,7 +123,7 @@ class InviteControllerTest {
         User user = new User("user-123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("mixtape-123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("mixtape-123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         LocalDateTime expiredDate = LocalDateTime.now().minusSeconds(1);
@@ -143,7 +143,7 @@ class InviteControllerTest {
         User user = new User("user-123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("mixtape-123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("mixtape-123", "my mixtape", "", "http://path/to/image", new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         LocalDateTime notExpiredDate = LocalDateTime.now().plusHours(1);

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -133,7 +133,7 @@ class MixtapeControllerTest {
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", "", new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", "", new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         // when + then
@@ -169,8 +169,8 @@ class MixtapeControllerTest {
 
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtapeOfLoggedInUser = new Mixtape("123", "mixtape of logged in user", "description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), loggedInUser);
-        Mixtape mixtapeOfOtherUser = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfLoggedInUser = new Mixtape("123", "mixtape of logged in user", "description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), loggedInUser, true);
+        Mixtape mixtapeOfOtherUser = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser, true);
 
         this.mixtapeRepository.saveAll(List.of(mixtapeOfLoggedInUser, mixtapeOfOtherUser));
 
@@ -187,7 +187,7 @@ class MixtapeControllerTest {
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         this.mvc.perform(delete("/api/mixtapes/" +  mixtapeOfOtherUser.getId())
@@ -204,7 +204,7 @@ class MixtapeControllerTest {
 
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         MixtapeUser mixtapeUser = new MixtapeUser(null, user, mixtapeOfOtherUser);
@@ -222,7 +222,7 @@ class MixtapeControllerTest {
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         this.mvc.perform(delete("/api/mixtapes/" +  mixtape.getId())
@@ -239,7 +239,7 @@ class MixtapeControllerTest {
 
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtape = new Mixtape("234", "existing mixtape", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtape = new Mixtape("234", "existing mixtape", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtape);
 
         String givenJson = """
@@ -274,7 +274,7 @@ class MixtapeControllerTest {
 
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("234", "existing mixtape", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("234", "existing mixtape", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         MixtapeUser mixtapeUser = new MixtapeUser(null, user, mixtapeOfOtherUser);
@@ -310,7 +310,7 @@ class MixtapeControllerTest {
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("234", "existing mixtape", "existing description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("234", "existing mixtape", "existing description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         String expectedJson = """
@@ -344,7 +344,7 @@ class MixtapeControllerTest {
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtape = new Mixtape("234", "existing mixtape", "existing description", null, new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtape = new Mixtape("234", "existing mixtape", "existing description", null, new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtape);
 
         // when + then
@@ -375,7 +375,7 @@ class MixtapeControllerTest {
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("234", "existing mixtape", "existing description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("234", "existing mixtape", "existing description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         // when + then
@@ -410,7 +410,7 @@ class MixtapeControllerTest {
         User otherUser = new User("234", null, "simon", null, Provider.SPOTIFY, null);
         this.userRepository.save(otherUser);
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("234", "existing mixtape", "existing description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("234", "existing mixtape", "existing description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         MixtapeUser mixtapeUser = new MixtapeUser(null, user, mixtapeOfOtherUser);

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -305,6 +305,40 @@ class MixtapeControllerTest {
     }
 
     @Test
+    void update_whenLoggedInButCanNotEditBecauseMixtapeIsNoDraftAnymore_thenReturnForbidden() throws Exception {
+        // given
+        User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
+        OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
+
+        Mixtape mixtape = new Mixtape("234", "existing mixtape", "existing description", "/path/to/mixtape/image", new ArrayList<>(), LocalDateTime.now(), user, false);
+        this.mixtapeRepository.save(mixtape);
+
+        String givenJson = """
+                {
+                    "id": "234",
+                    "title": "existing mixtape",
+                    "description": "updated description",
+                    "imageUrl": "http://path/to/mixtape/image",
+                    "createdBy": {
+                        "id": "123",
+                        "name": "alvin",
+                        "imageUrl": "/path/to/image"
+                    },
+                    "tracks": []
+                }
+                """;
+
+
+        // when + then
+        this.mvc.perform(put("/api/mixtapes/" + mixtape.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(givenJson)
+                        .with(oauth2Login().oauth2User(oAuth2User))
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void update_whenLoggedInAndCanEdit_thenReturnOk() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/MixtapeControllerTest.java
@@ -197,7 +197,7 @@ class MixtapeControllerTest {
     }
 
     @Test
-    void delete_whenLoggedInButCanNotEditBecauseIsOnlyListener_thenReturnForbidden() throws Exception {
+    void delete_whenLoggedInAndCanEditBecauseIsListener_thenReturnOk() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
@@ -214,15 +214,15 @@ class MixtapeControllerTest {
         this.mvc.perform(delete("/api/mixtapes/" +  mixtapeOfOtherUser.getId())
                         .with(oauth2Login().oauth2User(oAuth2User))
                 )
-                .andExpect(status().isForbidden());
+                .andExpect(status().isOk());
     }
 
     @Test
-    void delete_whenLoggedInAndCanEdit_thenReturnOk() throws Exception {
+    void delete_whenLoggedInAndCanEditBecauseIsCreator_thenReturnOk() throws Exception {
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("234", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), user, true);
+        Mixtape mixtape = new Mixtape("234", "mixtape", "", null, new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         this.mvc.perform(delete("/api/mixtapes/" +  mixtape.getId())

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
@@ -118,6 +118,34 @@ class TrackControllerTest {
     }
 
     @Test
+    void create_whenLoggedInButCanNotEditBecauseMixtapeIsNoDraftAnymore_thenReturnForbidden() throws Exception {
+        // given
+        User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
+        OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
+
+        Mixtape mixtape = new Mixtape("123", "mixtape", "", null, new ArrayList<>(), LocalDateTime.now(), user, false);
+        this.mixtapeRepository.save(mixtape);
+
+        String givenJson = """
+                {
+                    "name": "The Chipmunks Song",
+                    "artist": "Alvin & The Chipmunks",
+                    "imageUrl": "http://path/to/image",
+                    "description": null,
+                    "providerUri": "spotify:track:12345"
+                }
+                """;
+
+        // when + then
+        this.mvc.perform(post("/api/mixtapes/123/tracks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(givenJson)
+                        .with(oauth2Login().oauth2User(oAuth2User))
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void create_whenLoggedInAndCanEdit_thenReturnOk() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -254,6 +282,38 @@ class TrackControllerTest {
     }
 
     @Test
+    void update_whenLoggedInButCanNotEditBecauseMixtapeIsNoDraftAnymore_thenReturnForbidden() throws Exception {
+        // given
+        User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
+        OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
+
+        Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
+        this.trackRepository.save(track);
+
+        Mixtape mixtape = new Mixtape("123", "mixtape", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), user, false);
+        this.mixtapeRepository.save(mixtape);this.mixtapeRepository.save(mixtape);
+
+        String givenJson = """
+                {
+                    "id": "234",
+                    "name": "The Chipmunks Song",
+                    "artist": "Alvin & The Chipmunks",
+                    "imageUrl": "http://path/to/image",
+                    "description": "Updated description",
+                    "providerUri": "spotify:track:12345"
+                }
+                """;
+
+        // when + then
+        this.mvc.perform(put("/api/mixtapes/123/tracks/234")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(givenJson)
+                        .with(oauth2Login().oauth2User(oAuth2User))
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void update_whenTrackDoesNotExistOnMixtape_thenReturnNotFound() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -362,6 +422,25 @@ class TrackControllerTest {
     }
 
     @Test
+    void delete_whenLoggedInButCanNotEditBecauseMixtapeIsNoDraftAnymore_thenReturnForbidden() throws Exception {
+        // given
+        User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
+        OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
+
+        Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
+        this.trackRepository.save(track);
+
+        Mixtape mixtape = new Mixtape("123", "mixtape", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), user, false);
+        this.mixtapeRepository.save(mixtape);this.mixtapeRepository.save(mixtape);
+
+        // when + then
+        this.mvc.perform(delete("/api/mixtapes/123/tracks/234")
+                        .with(oauth2Login().oauth2User(oAuth2User))
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void delete_whenTrackDoesNotExistOnMixtape_thenReturnNotFound() throws Exception {
         // given
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
@@ -389,7 +468,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), user, true);
+        Mixtape mixtape = new Mixtape("123", "mixtape", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);this.mixtapeRepository.save(mixtape);
 
         // when + then

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/integration/mixtape/controller/TrackControllerTest.java
@@ -62,7 +62,7 @@ class TrackControllerTest {
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser();
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         String givenJson = """
@@ -92,7 +92,7 @@ class TrackControllerTest {
 
         User otherUser = this.testUserHelper.createUser("234");
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         MixtapeUser mixtapeUser = new MixtapeUser(null, user, mixtapeOfOtherUser);
@@ -123,7 +123,7 @@ class TrackControllerTest {
         User user = new User("123", "alvin@chipmunks.de", "alvin", "/path/to/image", Provider.SPOTIFY, "user-123");
         OAuth2User oAuth2User = this.testUserHelper.createLoginUser(user);
 
-        Mixtape mixtape = new Mixtape("123", "mixtape", "", null, new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("123", "mixtape", "", null, new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         String givenJson = """
@@ -162,7 +162,7 @@ class TrackControllerTest {
             tracks.add(track);
         }
 
-        Mixtape mixtape = new Mixtape("123", "mixtape", "", null, tracks, LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("123", "mixtape", "", null, tracks, LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         String givenJson = """
@@ -193,7 +193,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         String givenJson = """
@@ -227,7 +227,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         MixtapeUser mixtapeUser = new MixtapeUser(null, user, mixtapeOfOtherUser);
@@ -262,7 +262,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         String givenJson = """
@@ -294,7 +294,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);this.mixtapeRepository.save(mixtape);
 
         String givenJson = """
@@ -327,7 +327,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         // when + then
@@ -348,7 +348,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), otherUser);
+        Mixtape mixtapeOfOtherUser = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), otherUser, true);
         this.mixtapeRepository.save(mixtapeOfOtherUser);
 
         MixtapeUser mixtapeUser = new MixtapeUser(null, user, mixtapeOfOtherUser);
@@ -370,7 +370,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);
 
         // when + then
@@ -389,7 +389,7 @@ class TrackControllerTest {
         Track track = new Track("234", "The Chipmunks Song", "Alvin & The Chipmunks", "/path/to/image", null, "spotify:track:12345");
         this.trackRepository.save(track);
 
-        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), user);
+        Mixtape mixtape = new Mixtape("123", "mixtape of other user", "", null, new ArrayList<>(List.of(track)), LocalDateTime.now(), user, true);
         this.mixtapeRepository.save(mixtape);this.mixtapeRepository.save(mixtape);
 
         // when + then

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/security/MixtapePermissionServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/security/MixtapePermissionServiceTest.java
@@ -119,8 +119,9 @@ class MixtapePermissionServiceTest {
         assertTrue(actual);
     }
 
+
     @Test
-    void canView_whenUserIsNotCreatorOfMixtape_thenReturnFalse() {
+    void canEdit_whenUserIsNotCreatorOfMixtape_thenReturnFalse() {
         // given
         String mixtapeId = "123";
         User user = new User();
@@ -140,4 +141,68 @@ class MixtapePermissionServiceTest {
         // then
         assertFalse(actual);
     }
+
+    @Test
+    void canDelete_whenNotLoggedIn_thenThrowUnauthorizedException() {
+        // given
+        String mixtapeId = "123";
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.empty());
+
+        // when + then
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+
+        assertThrows(UnauthorizedException.class, () -> sut.canDelete(mixtapeId));
+    }
+
+    @Test
+    void canDelete_whenMixtapeUserEntryExistsForUserAndMixtape_thenReturnTrue() {
+        // given
+        User user = new User();
+
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId("123");
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+        when(mixtapeUserService.existsByUserAndMixtape(user, mixtape)).thenReturn(true);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+        boolean actual = sut.canDelete(mixtape.getId());
+
+        // then
+        assertTrue(actual);
+    }
+
+    @Test
+    void canDelete_whenMixtapeUserEntryDoesNotExistForUserAndMixtape_thenReturnFalse() {
+        // given
+        User user = new User();
+
+        Mixtape mixtape = new Mixtape();
+        mixtape.setId("123");
+
+        MixtapeService mixtapeService = mock(MixtapeService.class);
+        MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
+        when(mixtapeUserService.existsByUserAndMixtape(user, mixtape)).thenReturn(false);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
+
+        // when
+        MixtapePermissionService sut = new MixtapePermissionService(mixtapeService, mixtapeUserService, userService);
+        boolean actual = sut.canDelete(mixtape.getId());
+
+        // then
+        assertFalse(actual);
+    }
+
 }

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/security/MixtapePermissionServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/security/MixtapePermissionServiceTest.java
@@ -104,7 +104,7 @@ class MixtapePermissionServiceTest {
         User user = new User();
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.existsByIdAndCreatedBy(mixtapeId, user)).thenReturn(true);
+        when(mixtapeService.existsByIdAndCreatedByAndDraftTrue(mixtapeId, user)).thenReturn(true);
 
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
 
@@ -126,7 +126,7 @@ class MixtapePermissionServiceTest {
         User user = new User();
 
         MixtapeService mixtapeService = mock(MixtapeService.class);
-        when(mixtapeService.existsByIdAndCreatedBy(mixtapeId, user)).thenReturn(false);
+        when(mixtapeService.existsByIdAndCreatedByAndDraftTrue(mixtapeId, user)).thenReturn(false);
 
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
 

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
@@ -145,10 +145,11 @@ class MixtapeServiceTest {
     @Test
     void deleteByIdForAuthenticatedUser_whenMixtapeDoesNotExistOrDoesNotBelongToUser_thenThrowNotFoundException() {
         // given
+        String id = "123";
         User user = new User();
 
         Mixtape mixtape = new Mixtape();
-        mixtape.setId("123");
+        mixtape.setId(id);
 
         UserService userService = mock(UserService.class);
         when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
@@ -162,7 +163,7 @@ class MixtapeServiceTest {
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, mixtapeUserService, validator);
-        assertThrows(NotFoundException.class, () -> sut.deleteByIdForAuthenticatedUser(mixtape.getId()));
+        assertThrows(NotFoundException.class, () -> sut.deleteByIdForAuthenticatedUser(id));
 
         // then
         verify(mixtapeRepository, never()).deleteById(any());

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape/service/MixtapeServiceTest.java
@@ -119,7 +119,7 @@ class MixtapeServiceTest {
         assertThrows(UnauthorizedException.class, sut::findAllForAuthenticatedUser);
 
         // then
-        verify(mixtapeRepository, never()).findAllByCreatedBy(any());
+        verify(mixtapeUserService, never()).findAllByUser(any());
     }
 
     @Test
@@ -255,7 +255,7 @@ class MixtapeServiceTest {
         when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
 
         MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
-        when(mixtapeRepository.existsByIdAndCreatedBy(any(), eq(user))).thenReturn(false);
+        when(mixtapeRepository.existsByIdAndCreatedByAndDraftTrue(any(), eq(user))).thenReturn(false);
 
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
         Validator validator = mock(Validator.class);
@@ -285,7 +285,7 @@ class MixtapeServiceTest {
         when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
 
         MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
-        when(mixtapeRepository.existsByIdAndCreatedBy(expectedId, user)).thenReturn(true);
+        when(mixtapeRepository.existsByIdAndCreatedByAndDraftTrue(expectedId, user)).thenReturn(true);
         when(mixtapeRepository.save(expectedMixtape)).thenReturn(expectedMixtape);
 
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
@@ -314,7 +314,7 @@ class MixtapeServiceTest {
         when(userService.getAuthenticatedUser()).thenReturn(Optional.of(user));
 
         MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
-        when(mixtapeRepository.existsByIdAndCreatedBy(mixtape.getId(), user)).thenReturn(true);
+        when(mixtapeRepository.existsByIdAndCreatedByAndDraftTrue(mixtape.getId(), user)).thenReturn(true);
 
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
 
@@ -347,7 +347,7 @@ class MixtapeServiceTest {
         assertThrows(UnauthorizedException.class, () -> sut.findByIdForAuthenticatedUser("123"));
 
         // then
-        verify(mixtapeRepository, never()).findByIdAndCreatedBy(any(), any());
+        verify(mixtapeUserService, never()).findByUserAndMixtape(any(), any());
     }
 
     @Test
@@ -463,18 +463,18 @@ class MixtapeServiceTest {
         UserService userService = mock(UserService.class);
 
         MixtapeRepository mixtapeRepository = mock(MixtapeRepository.class);
-        when(mixtapeRepository.existsByIdAndCreatedBy(id, user)).thenReturn(expected);
+        when(mixtapeRepository.existsByIdAndCreatedByAndDraftTrue(id, user)).thenReturn(expected);
 
         MixtapeUserService mixtapeUserService = mock(MixtapeUserService.class);
         Validator validator = mock(Validator.class);
 
         // when
         MixtapeService sut = new MixtapeService(mixtapeRepository, userService, mixtapeUserService, validator);
-        boolean actual = sut.existsByIdAndCreatedBy(id, user);
+        boolean actual = sut.existsByIdAndCreatedByAndDraftTrue(id, user);
 
         // then
         assertEquals(expected, actual);
-        verify(mixtapeRepository).existsByIdAndCreatedBy(id, user);
+        verify(mixtapeRepository).existsByIdAndCreatedByAndDraftTrue(id, user);
     }
 
     /**

--- a/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
+++ b/backend/src/test/java/com/github/chuettenrauch/mixifyapi/unit/mixtape_user/service/MixtapeUserServiceTest.java
@@ -132,4 +132,38 @@ class MixtapeUserServiceTest {
         verify(mixtapeUserRepository).existsByUserAndMixtape(user, mixtape);
     }
 
+    @Test
+    void existsByMixtape_whenCalled_thenDelegateToMixtapeUserRepository() {
+        // given
+        Mixtape mixtape = new Mixtape();
+        boolean expected = true;
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+        when(mixtapeUserRepository.existsByMixtape(mixtape)).thenReturn(expected);
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository);
+        boolean actual = sut.existsByMixtape(mixtape);
+
+        // then
+        assertEquals(expected, actual);
+        verify(mixtapeUserRepository).existsByMixtape(mixtape);
+    }
+
+    @Test
+    void deleteByUserAndMixtape_whenCalled_thenDelegateToMixtapeUserRepository() {
+        // given
+        User user = new User();
+        Mixtape mixtape = new Mixtape();
+
+        MixtapeUserRepository mixtapeUserRepository = mock(MixtapeUserRepository.class);
+
+        // when
+        MixtapeUserService sut = new MixtapeUserService(mixtapeUserRepository);
+        sut.deleteByUserAndMixtape(user, mixtape);
+
+        // then
+        verify(mixtapeUserRepository).deleteByUserAndMixtape(user, mixtape);
+    }
+
 }

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,8 +1,9 @@
-import {Button, Dialog, DialogActions, DialogTitle} from "@mui/material";
+import {Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from "@mui/material";
 
-export default function ConfirmDialog({open, title, onCancel, onConfirm}: {
+export default function ConfirmDialog({open, title, text, onCancel, onConfirm}: {
     open: boolean,
     title: string,
+    text?: string,
     onCancel: () => void,
     onConfirm: () => void,
 }) {
@@ -14,6 +15,15 @@ export default function ConfirmDialog({open, title, onCancel, onConfirm}: {
             aria-describedby="confirm-dialog-description"
         >
             <DialogTitle id="confirm-dialog-title">{title}</DialogTitle>
+
+            {text &&
+              <DialogContent>
+                <DialogContentText id="confirm-dialog-description">
+                    {text}
+                </DialogContentText>
+              </DialogContent>
+            }
+
             <DialogActions>
                 <Button onClick={() => onCancel()}>Cancel</Button>
                 <Button onClick={() => onConfirm()} autoFocus>Confirm</Button>

--- a/frontend/src/components/MixtapeCard.tsx
+++ b/frontend/src/components/MixtapeCard.tsx
@@ -21,7 +21,7 @@ export default function MixtapeCard({mixtape, onEdit, onDelete}: {
     const {user} = useAuthenticatedUser();
     const navigate = useNavigate();
 
-    const canEdit = PermissionUtils.canEdit(user, mixtape);
+    const isEditable = PermissionUtils.isEditable(user, mixtape);
 
     return (
         <Card elevation={5} sx={{display: "flex", position: "relative"}}>
@@ -32,7 +32,7 @@ export default function MixtapeCard({mixtape, onEdit, onDelete}: {
                 />
             </CardActions>
 
-            <CardActionArea component={Link} to={canEdit ? `/mixtapes/${mixtape.id}` : `/play/${mixtape.id}`} sx={{
+            <CardActionArea component={Link} to={isEditable ? `/mixtapes/${mixtape.id}` : `/play/${mixtape.id}`} sx={{
                 display: "flex",
                 justifyContent: "flex-start",
                 alignItems: "stretch",
@@ -61,7 +61,7 @@ export default function MixtapeCard({mixtape, onEdit, onDelete}: {
             </CardActionArea>
 
             <CardActions>
-                {canEdit &&
+                {isEditable &&
                   <MixtapeMenu mixtape={mixtape} onEdit={onEdit} onDelete={onDelete}/>
                 }
             </CardActions>

--- a/frontend/src/components/MixtapeCard.tsx
+++ b/frontend/src/components/MixtapeCard.tsx
@@ -1,7 +1,7 @@
 import Mixtape from "../types/mixtape";
 import {
     Box,
-    Card, CardActionArea, CardActions, CardContent,
+    Card, CardActionArea, CardActions, CardContent, Chip,
     Container,
     Typography
 } from "@mui/material";
@@ -25,11 +25,19 @@ export default function MixtapeCard({mixtape, onEdit, onDelete}: {
 
     return (
         <Card elevation={5} sx={{display: "flex", position: "relative"}}>
-            <CardActions sx={{p: 2, pr: 0}}>
+            <CardActions sx={{p: 2, pr: 0, position: "relative"}}>
                 <CardImageWithPlayButton
                     image={{src: mixtape.imageUrl, alt: mixtape.title, size: 100}}
                     onClick={() => navigate(`/play/${mixtape.id}`)}
                 />
+
+                {mixtape.draft &&
+                  <Chip size="small" color="primary" label="Draft" sx={{
+                      position: "absolute",
+                      top: (theme) => theme.spacing(1),
+                      left: 0
+                  }}/>
+                }
             </CardActions>
 
             <CardActionArea component={Link} to={isEditable ? `/mixtapes/${mixtape.id}` : `/play/${mixtape.id}`} sx={{
@@ -61,9 +69,7 @@ export default function MixtapeCard({mixtape, onEdit, onDelete}: {
             </CardActionArea>
 
             <CardActions>
-                {isEditable &&
-                  <MixtapeMenu mixtape={mixtape} onEdit={onEdit} onDelete={onDelete}/>
-                }
+                <MixtapeMenu mixtape={mixtape} onEdit={onEdit} onDelete={onDelete}/>
             </CardActions>
         </Card>
     );

--- a/frontend/src/components/MixtapeMenu.tsx
+++ b/frontend/src/components/MixtapeMenu.tsx
@@ -27,8 +27,6 @@ export default function MixtapeMenu({mixtape, onDelete, onEdit, sx}: {
     sx?: SxProps<Theme>
 }) {
     const {user} = useAuthenticatedUser();
-    const isEditable = PermissionUtils.isEditable(user, mixtape);
-    const isCreator = PermissionUtils.isCreator(user, mixtape);
 
     const {menuAnchorEl: mixtapeAnchorEl, isMenuOpen: isMixtapeMenuOpen, openMenu: openMixtapeMenu, closeMenu: closeMixtapeMenu} = useMenu();
     const {isFormOpen: isMixtapeFormOpen, openForm: openMixtapeForm, closeForm: closeMixtapeForm} = useForm();
@@ -42,9 +40,9 @@ export default function MixtapeMenu({mixtape, onDelete, onEdit, sx}: {
     } = useConfirmDialog();
 
     const {
-        isConfirmDialogOpen: isPublishConfirmDialogOpen,
-        openConfirmDialog: openPublishConfirmDialog,
-        closeConfirmDialog: closePublishConfirmDialog
+        isConfirmDialogOpen: isFinalizeConfirmDialogOpen,
+        openConfirmDialog: openFinalizeConfirmDialog,
+        closeConfirmDialog: closeFinalizeConfirmDialog
     } = useConfirmDialog();
 
     useEffect(() => {
@@ -60,16 +58,19 @@ export default function MixtapeMenu({mixtape, onDelete, onEdit, sx}: {
         closeDeleteConfirmDialog();
     };
 
-    const handlePublishConfirmed = async() => {
+    const handleFinalizeConfirmed = async() => {
         const savedMixtape = await MixtapeApi.updateMixtape({...mixtape, draft: false});
         onEdit(savedMixtape);
 
-        toast.success("Successfully published mixtape.");
+        toast.success("Successfully finalizeed mixtape.");
 
-        closePublishConfirmDialog();
+        closeFinalizeConfirmDialog();
     }
 
     const mixtapeMenuId = `mixtape-${mixtape.id}-menu`;
+
+    const isEditable = PermissionUtils.isEditable(user, mixtape);
+    const isShareable = PermissionUtils.isShareable(user, mixtape);
 
     return (
         <>
@@ -101,7 +102,7 @@ export default function MixtapeMenu({mixtape, onDelete, onEdit, sx}: {
                     Edit
                   </MenuItem>
                 }
-                {isCreator && !isEditable &&
+                {isShareable &&
                   <MenuItem onClick={openShareModal}>
                     <ListItemIcon>
                       <ShareIcon fontSize="small"/>
@@ -110,7 +111,7 @@ export default function MixtapeMenu({mixtape, onDelete, onEdit, sx}: {
                   </MenuItem>
                 }
                 {isEditable &&
-                  <MenuItem onClick={openPublishConfirmDialog}>
+                  <MenuItem onClick={openFinalizeConfirmDialog}>
                     <ListItemIcon>
                       <SportsScore fontSize="small"/>
                     </ListItemIcon>
@@ -134,13 +135,13 @@ export default function MixtapeMenu({mixtape, onDelete, onEdit, sx}: {
               />
             }
 
-            {isPublishConfirmDialogOpen &&
+            {isFinalizeConfirmDialogOpen &&
               <ConfirmDialog
-                open={isPublishConfirmDialogOpen}
+                open={isFinalizeConfirmDialogOpen}
                 title={`Do you really want to finalize your mixtape "${mixtape.title}"?`}
                 text="You can't edit it afterwards anymore."
-                onCancel={closePublishConfirmDialog}
-                onConfirm={handlePublishConfirmed}
+                onCancel={closeFinalizeConfirmDialog}
+                onConfirm={handleFinalizeConfirmed}
               />
             }
 

--- a/frontend/src/pages/MixtapeDetailPage.tsx
+++ b/frontend/src/pages/MixtapeDetailPage.tsx
@@ -48,7 +48,7 @@ export default function MixtapeDetailPage() {
         return null;
     }
 
-    if (!PermissionUtils.canEdit(user, mixtape)) {
+    if (!PermissionUtils.isEditable(user, mixtape)) {
         return <NotFoundPage/>
     }
 

--- a/frontend/src/pages/MixtapeDetailPage.tsx
+++ b/frontend/src/pages/MixtapeDetailPage.tsx
@@ -13,7 +13,6 @@ import MessageContainer from "../components/MessageContainer";
 import Track from "../types/track";
 import {useAuthenticatedUser} from "../components/ProtectedRoutes";
 import PermissionUtils from "../utils/permission-utils";
-import NotFoundPage from "./NotFoundPage";
 import SortableTrackList from "../components/SortableTrackList";
 import {MixtapeApi} from "../api/mixify-api";
 import { move } from "move-position";
@@ -49,7 +48,7 @@ export default function MixtapeDetailPage() {
     }
 
     if (!PermissionUtils.isEditable(user, mixtape)) {
-        return <NotFoundPage/>
+        navigateToMixtapesOverviewPage();
     }
 
     const addTrack = (savedTrack: Track) => {

--- a/frontend/src/types/mixtape.ts
+++ b/frontend/src/types/mixtape.ts
@@ -9,6 +9,7 @@ type Mixtape = {
     createdAt: string,
     createdBy: User,
     tracks: Track[],
+    draft: boolean,
 }
 
 export default Mixtape;

--- a/frontend/src/utils/permission-utils.ts
+++ b/frontend/src/utils/permission-utils.ts
@@ -2,7 +2,7 @@ import {AuthenticatedUser} from "../types/user";
 import Mixtape from "../types/mixtape";
 
 namespace PermissionUtils {
-    export function isCreator(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
+    function isCreator(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
         if (!user || !mixtape) {
             return false;
         }
@@ -12,6 +12,10 @@ namespace PermissionUtils {
 
     export function isEditable(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
         return mixtape?.draft && isCreator(user, mixtape);
+    }
+
+    export function isShareable(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
+        return !mixtape?.draft && isCreator(user, mixtape);
     }
 }
 

--- a/frontend/src/utils/permission-utils.ts
+++ b/frontend/src/utils/permission-utils.ts
@@ -2,7 +2,7 @@ import {AuthenticatedUser} from "../types/user";
 import Mixtape from "../types/mixtape";
 
 namespace PermissionUtils {
-    export function hasEditPermission(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
+    export function isCreator(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
         if (!user || !mixtape) {
             return false;
         }
@@ -11,7 +11,7 @@ namespace PermissionUtils {
     }
 
     export function isEditable(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
-        return mixtape?.draft && hasEditPermission(user, mixtape);
+        return mixtape?.draft && isCreator(user, mixtape);
     }
 }
 

--- a/frontend/src/utils/permission-utils.ts
+++ b/frontend/src/utils/permission-utils.ts
@@ -2,12 +2,16 @@ import {AuthenticatedUser} from "../types/user";
 import Mixtape from "../types/mixtape";
 
 namespace PermissionUtils {
-    export function canEdit(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
+    export function hasEditPermission(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
         if (!user || !mixtape) {
             return false;
         }
 
         return user.id === mixtape.createdBy.id;
+    }
+
+    export function isEditable(user: AuthenticatedUser | null, mixtape: Mixtape | null) {
+        return mixtape?.draft && hasEditPermission(user, mixtape);
     }
 }
 


### PR DESCRIPTION
- mixtapes are only editable, while they are in draft mode
- mixtapes can only be shared, if not in draft mode anymore (aka finalized) - this ensures, that mixtape can not be changed anymore, while someone listens to it
- ensure, that shared mixtapes can be deleted from user accounts (but delete only removes relation between mixtape and user, not the mixtape itself)
- mixtape is only deleted, if no other users have access to it